### PR TITLE
Tree command and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,5 @@ poetry.toml
 # GnW Manager
 gnwmanager/firmware.bin
 /screenshot.png
+Core/Inc/buildinfo.h
+gnwmanager/buildinfo.py

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -14,7 +14,9 @@
 #include "gnwmanager.h"
 #include "gnwmanager_gui.h"
 #include "buttons.h"
+#include "buildinfo.h"
 
+#define GNWMANAGER_MAGIC 0x476e575f // "GnW_"
 
 typedef enum {  // For the gnwmanager state machine
     GNWMANAGER_IDLE                   ,
@@ -86,6 +88,15 @@ struct gnwmanager_comm {  // Values are read or written by the debugger
                         // so that addresses don't change.
     union {
         volatile struct{
+            // const: magic bytes
+            uint32_t magic;
+
+            // const: git hash
+            char git_hash[16];
+
+            // const: build time
+            uint32_t build_time;
+
             // output: Status register
             uint32_t status;
 
@@ -462,6 +473,9 @@ static void gnwmanager_run(void)
 void gnwmanager_main(void)
 {
     memset((void *)&comm, 0, sizeof(comm));
+    comm.magic = GNWMANAGER_MAGIC;
+    strncpy(&comm.git_hash, GIT_HASH, sizeof(GIT_HASH));
+    comm.build_time = BUILD_TIME;
     gui.status = &comm.status;
     gui.progress = &comm.progress;
     gui.upload_in_progress = &comm.upload_in_progress;

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,13 @@ $(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 $(BUILD_DIR):
 	@mkdir $@
 
+FORCE:
+
+Core/Inc/buildinfo.h: FORCE | $(BUILD_DIR)
+	$(V)./scripts/update_buildinfo.sh
+
+$(BUILD_DIR)/gnwmanager.o: Core/Inc/buildinfo.h
+
 
 
 OPENOCD ?= openocd

--- a/gnwmanager/cli/_start_gnwmanager.py
+++ b/gnwmanager/cli/_start_gnwmanager.py
@@ -2,7 +2,9 @@ import importlib.resources
 from time import sleep, time
 
 from ..time import timestamp_now
+from gnwmanager.buildinfo import GIT_HASH, BUILD_TIME
 
+GNWMANAGER_MAGIC = 0x476e575f   # "GnW_"
 
 def start_gnwmanager(force=False):
     """Load the Manager firmware into device SRAM, and run it.
@@ -23,26 +25,35 @@ def start_gnwmanager(force=False):
     target = session.target
     assert target is not None
 
-    target.reset_and_halt()
-    addr = 0x240E_6800
     with importlib.resources.path("gnwmanager", "firmware.bin") as f:
         firmware = f.read_bytes()
-        target.write_memory_block8(addr, firmware)
+        target.reset_and_halt()
 
-    target.write_int("status", 0)  # To be 100% sure there's nothing residual in RAM.
-    target.write_int("status_override", 0)  # To be 100% sure there's nothing residual in RAM.
+        # No need to program flashapp if it's already running the correct version
+        magic = target.read_int('magic')
+        git_hash = target.read_mem('git_hash')
+        git_hash_str = git_hash.decode("utf-8", "ignore").split('\0')[0]
+        build_time = target.read_int("build_time")
+        if magic == GNWMANAGER_MAGIC and git_hash_str == GIT_HASH and build_time == BUILD_TIME:
+            print('gnwmanager already running on the target, no need to flash again.')
+        else:
+            addr = 0x240E_6800
+            target.write_memory_block8(addr, firmware)
 
-    msp = int.from_bytes(firmware[:4], byteorder="little")
-    pc = int.from_bytes(firmware[4:8], byteorder="little")
-    target.write_core_register("msp", msp)
-    target.write_core_register("pc", pc)
+        target.write_int("status", 0)  # To be 100% sure there's nothing residual in RAM.
+        target.write_int("status_override", 0)  # To be 100% sure there's nothing residual in RAM.
 
-    target.resume()
-    target.wait_for_idle()
+        msp = int.from_bytes(firmware[:4], byteorder="little")
+        pc = int.from_bytes(firmware[4:8], byteorder="little")
+        target.write_core_register("msp", msp)
+        target.write_core_register("pc", pc)
 
-    start_gnwmanager.started = True
+        target.resume()
+        target.wait_for_idle()
 
-    target.write_int("utc_timestamp", timestamp_now())
+        start_gnwmanager.started = True
+
+        target.write_int("utc_timestamp", timestamp_now())
 
 
 start_gnwmanager.started = False

--- a/gnwmanager/cli/main.py
+++ b/gnwmanager/cli/main.py
@@ -25,6 +25,7 @@ from . import (
     screenshot,
     shell,
     start,
+    tree,
 )
 from ._start_gnwmanager import start_gnwmanager
 
@@ -47,6 +48,7 @@ app.command()(pull.pull)
 app.command()(push.push)
 app.command()(shell.shell)
 app.command()(start.start)
+app.command()(tree.tree)
 
 
 def version_callback(value: bool):

--- a/gnwmanager/cli/tree.py
+++ b/gnwmanager/cli/tree.py
@@ -9,8 +9,11 @@ from gnwmanager.cli._parsers import int_parser
 from gnwmanager.filesystem import get_filesystem
 
 
-def _tree(fs: LittleFS, path: str, depth: int, max_depth: int):
+def _tree(fs: LittleFS, path: str, depth: int, max_depth: int, prefix: str = ""):
     try:
+        if depth == 0:
+            print(f"\033[94m{path}\033[0m")
+        
         elements = list(fs.scandir(path))
         for idx, element in enumerate(elements):
             if element.type == 1:
@@ -30,18 +33,18 @@ def _tree(fs: LittleFS, path: str, depth: int, max_depth: int):
             except LittleFSError:
                 time_str = " " * 19
 
-            indent = ""
-            if depth > 0:
-                indent = "│   " * (depth - 1)
-                if idx == (len(elements) - 1):
-                    indent += "└── "
-                else:
-                    indent += "├── "
+            is_last_element = (idx == (len(elements) - 1))
+            indent = prefix
+            if is_last_element:
+                indent += "└── "
+            else:
+                indent += "├── "
             print(f"{indent}\033[90m[{element.size:7}B {typ} {time_str}] {color}{element.name}\033[0m")
 
             # Recursive call on subdirectory
             if element.type == 2 and depth < max_depth:
-                _tree(fs, fullpath, depth+1, max_depth)
+                next_prefix = prefix + ("    " if is_last_element else "│   ")
+                _tree(fs, fullpath, depth+1, max_depth, next_prefix)
     except LittleFSError as e:
         if e.code != -2:
             raise

--- a/gnwmanager/cli/tree.py
+++ b/gnwmanager/cli/tree.py
@@ -7,24 +7,24 @@ from typing_extensions import Annotated
 
 from gnwmanager.cli._parsers import int_parser
 from gnwmanager.filesystem import get_filesystem
+from gnwmanager.utils import Color, colored
 
 
 def _tree(fs: LittleFS, path: str, depth: int, max_depth: int, prefix: str = ""):
     try:
         if depth == 0:
-            print(f"\033[94m{path}\033[0m")
+            print(colored(Color.BLUE, path))
         
         elements = list(fs.scandir(path))
         for idx, element in enumerate(elements):
+            color = Color.NONE
             if element.type == 1:
                 typ = "FILE"
-                color = "\033[0m"
             elif element.type == 2:
                 typ = "DIR "
-                color = "\033[94m"
+                color = Color.BLUE
             else:
                 typ = "UKWN"
-                color = "\033[0m"
 
             fullpath = f"{path}/{element.name}"
             try:
@@ -39,7 +39,8 @@ def _tree(fs: LittleFS, path: str, depth: int, max_depth: int, prefix: str = "")
                 indent += "└── "
             else:
                 indent += "├── "
-            print(f"{indent}\033[90m[{element.size:7}B {typ} {time_str}] {color}{element.name}\033[0m")
+            metadata = colored(Color.BLACK, f"[{element.size:7}B {typ} {time_str}]")
+            print(f"{indent}{metadata} {colored(color, element.name)}")
 
             # Recursive call on subdirectory
             if element.type == 2 and depth < max_depth:

--- a/gnwmanager/cli/tree.py
+++ b/gnwmanager/cli/tree.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from littlefs import LittleFS, LittleFSError
+from typer import Argument, Option
+from typing_extensions import Annotated
+
+from gnwmanager.cli._parsers import int_parser
+from gnwmanager.filesystem import get_filesystem
+
+
+def _tree(fs: LittleFS, path: str, depth: int, max_depth: int):
+    try:
+        elements = list(fs.scandir(path))
+        for idx, element in enumerate(elements):
+            if element.type == 1:
+                typ = "FILE"
+                color = "\033[0m"
+            elif element.type == 2:
+                typ = "DIR "
+                color = "\033[94m"
+            else:
+                typ = "UKWN"
+                color = "\033[0m"
+
+            fullpath = f"{path}/{element.name}"
+            try:
+                time_val = int.from_bytes(fs.getattr(fullpath, "t"), byteorder="little")
+                time_str = datetime.fromtimestamp(time_val, timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            except LittleFSError:
+                time_str = " " * 19
+
+            indent = ""
+            if depth > 0:
+                indent = "│   " * (depth - 1)
+                if idx == (len(elements) - 1):
+                    indent += "└── "
+                else:
+                    indent += "├── "
+            print(f"{indent}\033[90m[{element.size:7}B {typ} {time_str}] {color}{element.name}\033[0m")
+
+            # Recursive call on subdirectory
+            if element.type == 2 and depth < max_depth:
+                _tree(fs, fullpath, depth+1, max_depth)
+    except LittleFSError as e:
+        if e.code != -2:
+            raise
+        print(f"ls {path}: No such directory")
+
+
+def tree(
+    path: Annotated[
+        Path,
+        Argument(
+            help="On-device folder path to list. Defaults to root",
+        ),
+    ] = Path(),
+    depth: Annotated[
+        int,
+        Option(
+            min=0,
+            parser=int_parser,
+            help="Maximum depth of the directory tree.",
+        ),
+    ] = 2,
+    offset: Annotated[
+        int,
+        Option(
+            min=0,
+            parser=int_parser,
+            help="Distance in bytes from the END of the filesystem, to the END of flash.",
+        ),
+    ] = 0,
+):
+    """List contents of device directory and its descendants."""
+    from .main import session
+
+    target = session.target
+    fs = get_filesystem(target, offset=offset)
+    _tree(fs, path.as_posix(), 0, depth)

--- a/gnwmanager/target.py
+++ b/gnwmanager/target.py
@@ -28,7 +28,10 @@ contexts = [{} for i in range(2)]
 
 def _populate_comm():
     # Communication Variables; put in a function to prevent variable leakage.
-    _comm["status"] = last_variable = Variable(_comm["flashapp_comm"].address, 4)
+    _comm["magic"] = last_variable = Variable(_comm["flashapp_comm"].address, 4)
+    _comm["git_hash"] = last_variable = Variable(last_variable.address + last_variable.size, 16)
+    _comm["build_time"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
+    _comm["status"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
     _comm["status_override"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
     _comm["utc_timestamp"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
     _comm["progress"] = last_variable = Variable(last_variable.address + last_variable.size, 4)

--- a/gnwmanager/utils.py
+++ b/gnwmanager/utils.py
@@ -2,9 +2,23 @@ import hashlib
 import lzma
 import struct
 from pathlib import Path
-
+from enum import Enum
 from PIL import Image
 
+
+class Color(Enum):
+    NONE = 0
+    BLACK = 90
+    RED = 91
+    GREEN = 92
+    YELLOW = 93
+    BLUE = 94
+    MAGENTA = 95
+    CYAN = 96
+    WHITE = 97
+
+def colored(color: Color, text: str) -> str:
+    return f"\033[{color.value}m{text}\033[{Color.NONE.value}m"
 
 def sha256(data) -> bytes:
     return hashlib.sha256(data).digest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = ""
 authors = ["Brian Pugh"]
 readme = "README.md"
 packages = [{include = "gnwmanager"}]
-include = ["gnwmanager/firmware.bin"]
+include = ["gnwmanager/firmware.bin","gnwmanager/buildinfo.py"]
 
 [tool.poetry.build]
 generate-setup-file = false

--- a/scripts/update_buildinfo.sh
+++ b/scripts/update_buildinfo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+buildinfo_h="Core/Inc/buildinfo.h"
+buildinfo_py="gnwmanager/buildinfo.py"
+
+TMPFILE=$(mktemp build/buildinfo.XXXXXX)
+if [[ ! -e $TMPFILE ]]; then
+    echo "Can't create tempfile!"
+    exit 1
+fi
+
+GITHASH=$(git describe --always --dirty=+ 2> /dev/null || echo "NOGIT")
+TIMESTAMP=$(date +%s)
+
+echo -e "#ifndef GIT_HASH\n#define GIT_HASH \""${GITHASH}"\"\n#endif" > "${TMPFILE}"
+echo -e "#ifndef BUILD_TIME\n#define BUILD_TIME "${TIMESTAMP}"\n#endif" >> "${TMPFILE}"
+
+if ! diff -q ${TMPFILE} ${buildinfo_h} > /dev/null 2> /dev/null; then
+    echo "Updating build info file ${buildinfo_h}"
+    cp -f "${TMPFILE}" "${buildinfo_h}"
+fi
+
+rm -f "${TMPFILE}"
+
+echo -e "GIT_HASH = u\""${GITHASH}"\"" > "${TMPFILE}"
+echo -e "BUILD_TIME = "${TIMESTAMP} >> "${TMPFILE}"
+
+if ! diff -q ${TMPFILE} ${buildinfo_py} > /dev/null 2> /dev/null; then
+    echo "Updating build info file ${buildinfo_py}"
+    cp -f "${TMPFILE}" "${buildinfo_py}"
+fi
+
+rm -f "${TMPFILE}"


### PR DESCRIPTION
Hi @BrianPugh 

Not sure if this should be merged or not.

I added a `tree` command to list subdirectories (mostly because I'm lazy and didn't like typing multiple `ls` commands :sweat_smile:). I used colored output to make it readable, but I'm not sure how this would work with terminals that don't support colors.

I also made `start_gnwmanager` not reflash the gnw app if it's already running the correct version (this is done by checking magic bytes, git hash and build timestamp). The app is then simply restarted.

I can make separate PRs for both features if needed.

What do you think?