### PR TITLE
remove build script to make installing from source distribution easier

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,7 @@ jobs:
         run: poetry build
 
       - name: Publish package
+        if: github.event_name != 'workflow_dispatch'
         run: poetry publish
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction --no-dev
 
+      - name: Build stm32 firmwares
+        run: make -j4
+
       - name: Build package
         run: poetry build
 

--- a/README.md
+++ b/README.md
@@ -140,3 +140,22 @@ $ gnwmanager --help
 
 ## Need Help?
 If you need any help, either open up a github issue here, or join the [stacksmashing discord](https://discord.gg/zBN3ex8v4p) for live help.
+
+## Developer Installation
+If developing for GnWManager, perform the following steps to setup your local environment.
+We use [pre-commit](https://pre-commit.com/) to run linting, and [poetry](https://python-poetry.org/) for python management.
+
+```bash
+git clone git@github.com:BrianPugh/gnwmanager.git
+cd gnwmanager
+pre-commit install  # Ensures linting passes prior to committing
+poetry install
+make -j4  # Builds stm32 firmware binaries.
+```
+
+When changing C sources, `make` must be re-ran to update the binaries located at:
+
+```bash
+gnwmanager/firmware.bin
+gnwmanager/unlock.bin
+```

--- a/build.py
+++ b/build.py
@@ -1,9 +1,0 @@
-import subprocess
-
-
-def main():
-    subprocess.check_output(["make", "-j4"])
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,6 @@ readme = "README.md"
 packages = [{include = "gnwmanager"}]
 include = ["gnwmanager/firmware.bin", "gnwmanager/unlock.bin"]
 
-[tool.poetry.build]
-generate-setup-file = false
-script = 'build.py'
-
 [tool.poetry.scripts]
 gnwmanager = "gnwmanager.cli.main:run_app"
 


### PR DESCRIPTION
Removes build script so it  doesn't run when installing from source distribution. Otherwise people may run into things like:

```
$ pipx install gnwmanager
Fatal error from pip prevented installation. Full pip output in file:
    /Users/brianpugh/.local/pipx/logs/cmd_2023-10-25_11.17.42_pip_errors.log

pip failed to build package:
    gnwmanager

Some possibly relevant errors from pip install:
    error: subprocess-exited-with-error
    subprocess.CalledProcessError: Command '['make', '-j4']' returned non-zero exit status 2.
    subprocess.CalledProcessError: Command '['/Users/brianpugh/.local/pipx/venvs/gnwmanager/bin/python', 'build.py']' returned non-zero exit status 1.

Error installing gnwmanager.
```