### PR TITLE
Move Pi GPIO openocd to last to prefer debug probe

### DIFF
--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -43,17 +43,6 @@ def _openocd_launch_commands(port: int) -> Generator[List[str], None, None]:
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
     yield cmd
 
-    # Raspberry Pi GPIO
-    cmd = base_cmd.copy()
-    cmd.extend(["-c", "adapter speed 1000"])
-    cmd.extend(["-c", "source [find interface/sysfsgpio-raspberrypi.cfg]"])
-    # SWCLK - GPIO25, physical pin 22
-    # SWDIO - GPIO24, physical pin 18
-    cmd.extend(["-c", "sysfsgpio_swd_nums 25 24"])
-    cmd.extend(["-c", "transport select swd"])
-    cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
-    yield cmd
-
     # J-Link
     cmd = base_cmd.copy()
     cmd.extend(["-c", "adapter speed 4000"])
@@ -66,6 +55,17 @@ def _openocd_launch_commands(port: int) -> Generator[List[str], None, None]:
     cmd = base_cmd.copy()
     cmd.extend(["-c", "adapter speed 500"])
     cmd.extend(["-c", "source [find interface/cmsis-dap.cfg]"])
+    cmd.extend(["-c", "transport select swd"])
+    cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
+    yield cmd
+
+    # Raspberry Pi GPIO
+    cmd = base_cmd.copy()
+    cmd.extend(["-c", "adapter speed 1000"])
+    cmd.extend(["-c", "source [find interface/sysfsgpio-raspberrypi.cfg]"])
+    # SWCLK - GPIO25, physical pin 22
+    # SWDIO - GPIO24, physical pin 18
+    cmd.extend(["-c", "sysfsgpio_swd_nums 25 24"])
     cmd.extend(["-c", "transport select swd"])
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
     yield cmd


### PR DESCRIPTION
Move GPIO connection to last so any other probes will be used if they are connected to a Raspberry Pi.