### PR TITLE
Cmd info

### DIFF
--- a/gnwmanager/cli/info.py
+++ b/gnwmanager/cli/info.py
@@ -1,0 +1,20 @@
+from .unlock import DeviceModel
+
+
+def display(field, value):
+    print(f"{field:<28} {value}")
+
+
+def info():
+    """Displays environment & device info.
+
+    Note: part of this command exists in ``gnwmanager/cli/main.py``
+    """
+    from .main import gnw
+
+    display("Debug Probe:", gnw.backend.probe_name)
+
+    device = DeviceModel.autodetect(gnw)
+    display("Detected Device:", str(device).upper())
+
+    display("External Flash Size (MB):", str(gnw.external_flash_size / (1 << 20)))

--- a/gnwmanager/ocdbackend/base.py
+++ b/gnwmanager/ocdbackend/base.py
@@ -81,3 +81,8 @@ class OCDBackend(Registry, suffix="Backend"):
     def start_gdbserver(self, port, logging=True, blocking=True):
         """Start a blocking GDB Server."""
         raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def probe_name(self) -> str:
+        pass

--- a/gnwmanager/ocdbackend/base.py
+++ b/gnwmanager/ocdbackend/base.py
@@ -85,4 +85,4 @@ class OCDBackend(Registry, suffix="Backend"):
     @property
     @abstractmethod
     def probe_name(self) -> str:
-        pass
+        raise NotImplementedError

--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -228,3 +228,7 @@ class OpenOCDBackend(OCDBackend):
         if blocking:
             while True:
                 sleep(1)
+
+    @property
+    def probe_name(self) -> str:
+        return self("adapter name", decode=False).decode()

--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -51,9 +51,9 @@ def _openocd_launch_commands(port: int) -> Generator[List[str], None, None]:
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
     yield cmd
 
-    # CMSIS-DAP
+    # CMSIS-DAP (pi pico)
     cmd = base_cmd.copy()
-    cmd.extend(["-c", "adapter speed 500"])
+    cmd.extend(["-c", "adapter speed 4000"])
     cmd.extend(["-c", "source [find interface/cmsis-dap.cfg]"])
     cmd.extend(["-c", "transport select swd"])
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
@@ -127,6 +127,7 @@ class OpenOCDBackend(OCDBackend):
                 break
             except (OSError, ConnectionRefusedError):
                 sleep(0.5)
+
         return self
 
     def close(self):

--- a/gnwmanager/ocdbackend/pyocd_backend.py
+++ b/gnwmanager/ocdbackend/pyocd_backend.py
@@ -111,3 +111,7 @@ class PyOCDBackend(OCDBackend):
         if blocking:
             while gdb.is_alive():
                 sleep(0.1)
+
+    @property
+    def probe_name(self) -> str:
+        return self.probe.product_name


### PR DESCRIPTION
Produces some debugging outputs that may be useful for assisting people online. Example output:

```
$ gnwmanager info
Platform:                    macOS-13.4.1-arm64-arm-64bit
Python Version:              3.11.4 (main, Aug  3 2023, 10:05:00) [Clang 14.0.3 (clang-1403.0.22.14.1)]
GnWManager Executable:       /Users/brianpugh/projects/gnwmanager/.venv/bin/gnwmanager
GnWManager Version:          0.0.0
OCD Backend:                 openocd
Debug Probe:                 cmsis-dap
Detected Device:             ZELDA
External Flash Size (MB):    4.0
```