### PR TITLE
Add error-handling for bad external flash.

### DIFF
--- a/Core/Inc/flash.h
+++ b/Core/Inc/flash.h
@@ -30,6 +30,6 @@ void OSPI_ReadCR(uint8_t dest[1]);
 const char* OSPI_GetFlashName(void);
 uint32_t OSPI_GetSmallestEraseSize(void);
 
-void OSPI_Init(OSPI_HandleTypeDef *hospi);
+int OSPI_Init(OSPI_HandleTypeDef *hospi);
 
 uint32_t OSPI_GetSize(void);

--- a/Core/Inc/gnwmanager.h
+++ b/Core/Inc/gnwmanager.h
@@ -9,6 +9,7 @@ enum gnwmanager_status { // For signaling program status to computer
     GNWMANAGER_STATUS_NOT_ALIGNED     = 0xbad00003,
     GNWMANAGER_STATUS_BAD_DECOMPRESS  = 0xbad00004,
     GNWMANAGER_STATUS_BAD_SEGFAULT   = 0xbad00005,
+    GNWMANAGER_STATUS_BAD_FLASH_COMM   = 0xbad00006,
 
     GNWMANAGER_STATUS_IDLE            = 0xcafe0000,
     GNWMANAGER_STATUS_ERASE     ,
@@ -18,4 +19,5 @@ enum gnwmanager_status { // For signaling program status to computer
 typedef uint32_t gnwmanager_status_t;  // All computer interactions are uint32_t for simplicity.
                                     // No need to be stingy about RAM.
 
-void gnwmanager_main(void);
+void gnwmanager_main(gnwmanager_status_t status);
+void gnwmanager_set_status(gnwmanager_status_t status);

--- a/Core/Src/flash.c
+++ b/Core/Src/flash.c
@@ -840,7 +840,7 @@ uint32_t OSPI_GetSmallestEraseSize(void)
     return flash.config->erase_sizes[0];
 }
 
-void OSPI_Init(OSPI_HandleTypeDef *hospi)
+int OSPI_Init(OSPI_HandleTypeDef *hospi)
 {
     uint8_t status;
 
@@ -861,7 +861,8 @@ void OSPI_Init(OSPI_HandleTypeDef *hospi)
     // Check for known bad IDs
     if (((flash.jedec_id.u32 & 0xffffff) == 0xffffff) ||
         ((flash.jedec_id.u32 & 0xffffff) == 0x000000)) {
-        assert(!"Can't communicate with the external flash! Please check the soldering.");
+        // Can't communicate with the external flash! Please check the soldering.
+        return -1;
     }
 
     OSPI_ReadBytes(CMD(RDSR), 0, &status, 1);
@@ -882,6 +883,8 @@ void OSPI_Init(OSPI_HandleTypeDef *hospi)
     }
 
     OSPI_EnableMemoryMappedMode();
+
+    return 0;
 }
 
 uint32_t OSPI_GetSize(void){

--- a/Core/Src/gnwmanager_gui.c
+++ b/Core/Src/gnwmanager_gui.c
@@ -160,7 +160,8 @@ void gnwmanager_gui_draw(){
     );
 
     DRAW(ERROR2_ORIGIN_X, ERROR2_ORIGIN_Y, &img_flash,
-            *gui.status == GNWMANAGER_STATUS_BAD_HASH_FLASH
+            (*gui.status == GNWMANAGER_STATUS_BAD_HASH_FLASH)
+            || (*gui.status == GNWMANAGER_STATUS_BAD_FLASH_COMM)
     );
     DRAW(ERROR2_ORIGIN_X + 65, ERROR2_ORIGIN_Y, &img_ram,
             *gui.status == GNWMANAGER_STATUS_BAD_HASH_RAM

--- a/gnwmanager/cli/main.py
+++ b/gnwmanager/cli/main.py
@@ -234,7 +234,10 @@ def main(
         rich.print(f"[red]Error communicating with device ({e}). Is it ON and connected?[/red]")
         close_on_exit = False
     except DataError as e:
-        rich.print(f"Unexpected response from debug probe. {e}")
+        if e.args == ("BAD_FLASH_COMM",):
+            rich.print("Failed to communicate with external flash chip. Check your soldering!")
+        else:
+            rich.print(f"Unexpected response from debug probe. {e}")
     except ConnectionResetError:
         print(traceback.format_exc())
         close_on_exit = False

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -488,7 +488,7 @@ class GnW:
 
         self.wait_for_all_contexts_complete()
 
-    def start_gnwmanager(self, force=False):
+    def start_gnwmanager(self, force=False, resume=True):
         if not force and self._gnwmanager_started:
             return
 
@@ -513,11 +513,13 @@ class GnW:
         self.backend.write_register("pc", pc)
 
         log.debug("Resuming chip execution.")
-        self.backend.resume()
-        self.wait_for_idle()
 
         log.debug("Setting device time.")
         self.write_uint32("utc_timestamp", timestamp_now())
+
+        if resume:
+            self.backend.resume()
+            self.wait_for_idle()
 
         self._gnwmanager_started = True
 

--- a/gnwmanager/status.py
+++ b/gnwmanager/status.py
@@ -4,6 +4,8 @@ flashapp_status_enum_to_str = {
     0xBAD00002: "BAD_HASH_FLASH",
     0xBAD00003: "NOT_ALIGNED",
     0xBAD00004: "BAD_DECOMPRESS",
+    0xBAD00005: "BAD_SEGFAULT",
+    0xBAD00006: "BAD_FLASH_COMM",
     0xCAFE0000: "IDLE",
     0xCAFE0001: "ERASE",
     0xCAFE0002: "PROG",

--- a/tutorials/development.md
+++ b/tutorials/development.md
@@ -1,0 +1,19 @@
+## Build GnWManager with debugging symbols
+```
+make clean
+DEBUG=1 make
+```
+
+## Dropping into debugger.
+Press the power button and enter the following at the same time:
+```
+gnwmanager debug gdb
+```
+
+
+## Common GDB Commands
+After dropping into the debugger, it'd be common to set a breakpoint.
+
+```
+(gdb) break Core/Src/main.c:main
+```


### PR DESCRIPTION
At some point in the future, it might be better to just error-out if external-flash related commands are triggered, but this is pretty useful for now.