### PR TITLE
fix poweroff when switching to OFW from custom firmware

### DIFF
--- a/gnwmanager/cli/gnw_patch/mario.py
+++ b/gnwmanager/cli/gnw_patch/mario.py
@@ -46,6 +46,10 @@ class MarioGnW(Device, name="mario"):
         log.debug("Intercept button presses for macros.")
         self.internal.bl(0x6B52, "read_buttons")
 
+        log.debug("Warm-boot power-off fix: force standby-wake init path + skip state-6 standby.")
+        self.internal.nop(0x6038, 1)     # 0x08006030 SBF gate: bpl -> nop (always return 1)
+        self.internal.b(0x5F08, 0x5F2A)  # 0x08005EF4 state-6 standby: bpl -> b (never standby)
+
         log.debug("Mute clock audio on first boot.")
         self.internal.asm(0x49E0, "mov.w r1, #0x00000")
 

--- a/gnwmanager/cli/gnw_patch/zelda.py
+++ b/gnwmanager/cli/gnw_patch/zelda.py
@@ -135,6 +135,10 @@ class ZeldaGnW(Device, name="zelda"):
         log.debug("Intercept button presses for macros.")
         self.internal.bl(0xFE54, "read_buttons")
 
+        log.debug("Warm-boot power-off fix: force standby-wake init path + skip state-6 standby.")
+        self.internal.nop(0xEBD0, 1)      # 0x0800EBC8 SBF gate: bpl -> nop (always return 1)
+        self.internal.b(0xEAA0, 0xEAC2)   # 0x0800EA8C state-6 standby: bpl -> b (never standby)
+
         # Disable OTFDEC
         self.internal.nop(0x16536, 2)
         self.internal.nop(0x1653A, 1)


### PR DESCRIPTION
When switching to OFW via warm boot it turns the console off requiring pressing the power button. This fixes that so switching to OFW happens smoothly without needing to press the power button. 

Two byte-patches per firmware: skip the SBF gate and the state-6 standby. 
- NOP the SBF gate's branch → always takes the full cold-boot init path.
- Make the in-loop "state-6" standby an unconditional skip → a warm entry  stays alive instead of powering off.