### PR TITLE
Add external-flash offset support (Mario); deny it for Zelda

### DIFF
--- a/gnwmanager/cli/_patch.py
+++ b/gnwmanager/cli/_patch.py
@@ -8,7 +8,7 @@ from cyclopts import App, Group, Parameter, validators
 from cyclopts.types import ExistingBinPath
 
 from gnwmanager.cli._bootloader import flash_bootloader
-from gnwmanager.cli._parsers import GnWType
+from gnwmanager.cli._parsers import GnWType, int_parser
 from gnwmanager.cli.gnw_patch.exception import NotEnoughSpaceError
 from gnwmanager.cli.gnw_patch.mario import MarioGnW
 from gnwmanager.cli.gnw_patch.zelda import ZeldaGnW
@@ -77,6 +77,7 @@ def mario(
     no_smb2: Annotated[bool, Parameter(group=low_level_flash_group)] = False,
     slim: Annotated[bool, Parameter(group=high_level_flash_group)] = False,
     internal_only: Annotated[bool, Parameter(group=high_level_flash_group)] = False,
+    ext_offset: Annotated[int, Parameter(group=low_level_flash_group, converter=int_parser)] = 0,
 ):
     """Patch & Flash original mario firmware.
 
@@ -117,6 +118,10 @@ def mario(
         Remove bulky easter eggs (mario song and sleeping images) from extflash.
     internal_only: bool
         Configuration so no external flash is used.
+    ext_offset: int
+        Relocate external flash to this offset (hex ok, e.g. 0x400000) instead of the
+        default 0x90000000, so the OFW can coexist with other data on a large SPI flash.
+        Must be a multiple of 4096. Defaults to 0 (no offset).
     """
     if internal_only:
         slim = True
@@ -138,6 +143,7 @@ def mario(
         no_sleep_images=no_sleep_images,
         no_smb2=no_smb2,
         compression_ratio=1.4,
+        offset_size=ext_offset,
     )
 
     internal_remaining_free, compressed_memory_remaining_free = device()
@@ -150,7 +156,7 @@ def mario(
     gnw.start_gnwmanager()
     gnw.flash(1, 0, bytes(device.internal), progress=False)
     if device.external:
-        gnw.flash(0, 0, bytes(device.external), progress=True, desc="patched firmware")
+        gnw.flash(0, ext_offset, bytes(device.external), progress=True,  desc="patched firmware")
     if bootloader:
         flash_bootloader(0x08032000, gnw=gnw, repo=bootloader_repo, tag=bootloader_tag, label="0x08032000")
 
@@ -168,6 +174,7 @@ def zelda(
     no_sleep_images: Annotated[bool, Parameter(group=low_level_flash_group)] = False,
     no_second_beep: Annotated[bool, Parameter(group=low_level_flash_group)] = False,
     no_hour_tune: Annotated[bool, Parameter(group=low_level_flash_group)] = False,
+    ext_offset: Annotated[int, Parameter(group=low_level_flash_group, converter=int_parser)] = 0,
 ):
     """Patch & Flash original zelda firmware.
 
@@ -199,6 +206,10 @@ def zelda(
         Remove the second beep in TIME/CLOCK.
     no_hour_tune: bool
         Remove the hour tune in TIME/CLOCK.
+    ext_offset: int
+        Not supported for the Zelda OFW: it has no relocatable base and reaches its
+        external data via absolute pointers, so the data cannot be offset. A nonzero
+        value is rejected; only 0 is accepted. Defaults to 0.
     """
     device = _common_prepare(ZeldaGnW, internal, external, bootloader)
 
@@ -207,6 +218,7 @@ def zelda(
         no_sleep_images=no_sleep_images,
         no_second_beep=no_second_beep,
         no_hour_tune=no_hour_tune,
+        offset_size=ext_offset,
     )
 
     internal_remaining_free, compressed_memory_remaining_free = device()

--- a/gnwmanager/cli/gnw_patch/firmware.py
+++ b/gnwmanager/cli/gnw_patch/firmware.py
@@ -95,6 +95,7 @@ class Firmware(FirmwarePatchMixin, bytearray):
 
     FLASH_BASE = 0x0000_0000
     FLASH_LEN = 0
+    _offset = 0  # external-flash relocation offset added to lookup destinations; nonzero only on self.external
 
     def __init__(self, firmware=None):
         if firmware:
@@ -495,8 +496,9 @@ class Device:
         if delete:
             src.clear_range(src_offset, src_offset + size)
 
+        dst_base = dst.FLASH_BASE + dst._offset
         for i in range(size):
-            self.lookup[src.FLASH_BASE + src_offset + i] = dst.FLASH_BASE + dst_offset + i
+            self.lookup[src.FLASH_BASE + src_offset + i] = dst_base + dst_offset + i
 
         return size
 
@@ -687,6 +689,7 @@ class Device:
     def __call__(self):
         from . import MarioGnW, ZeldaGnW
 
+        self.external._offset = getattr(self.args, "offset_size", 0)
         self.int_pos = self.internal.empty_offset
         out = self.patch()
 

--- a/gnwmanager/cli/gnw_patch/mario.py
+++ b/gnwmanager/cli/gnw_patch/mario.py
@@ -40,6 +40,16 @@ class MarioGnW(Device, name="mario"):
         FLASH_LEN = 0x24100000 - FLASH_BASE
 
     def patch(self):
+        if self.args.offset_size:
+            base_addr = 0x9000_0000 + self.args.offset_size
+            try:
+                self.internal.asm(0x1066C, f"mov.w r3, #{hex(base_addr)}")
+            except Exception:
+                # If invalid immediate, load from literal pool (KEY_OFFSET = 0x106F4)
+                # ldr r3, [pc, #0x84] (2 bytes) + nop (2 bytes)
+                self.internal.replace(0x1066C, bytes.fromhex("214b00bf"))
+                self.internal.replace(0x106F4, base_addr, size=4)
+
         log.debug("Invoke custom bootloader prior to calling stock Reset_Handler.")
         self.internal.replace(0x4, "bootloader")
 
@@ -391,8 +401,8 @@ class MarioGnW(Device, name="mario"):
 
         # What is this data?
         # The memcpy to this address is all zero, so i guess its not used?
-        self.external.replace(0xF5858, b"\x00" * 34728)  # refence at internal 0x7210
-        self.ext_offset -= 34728
+        self.external.replace(0xF5858, b"\x00" * 34728)
+        self.move_ext(0xF5858, 34728, 0x7210)
 
         if self.compressed_memory_pos:
             # Compress and copy over compressed_memory
@@ -423,25 +433,61 @@ class MarioGnW(Device, name="mario"):
 
             self.ext_offset -= 8192
         else:
+            # NVRAM save banks: low bank = 0xfe000 + ext_offset, high bank = +0x1000.
+            # When the external image is relocated by offset_size (see top of
+            # patch()), the save target MUST be shifted too -- otherwise the
+            # un-offset address (e.g. 0xd9000) lands inside the OTHER console's
+            # external data (it falls in Zelda's Link's Awakening ROM at
+            # 0xd2000-0x1f4c00), and every Mario save silently corrupts it.
+            #
+            # 0xfe000 + ext_offset + offset_size (e.g. 0x4d9000) is not a Thumb-2
+            # modified immediate, and the original 10-byte "ite/mov.w/mov.w" slot
+            # can't hold movw+movt. So park the low-bank address in a free literal
+            # word and load it, then add 0x1000 for the high bank (still 10 bytes):
+            #     ldr.w r4, [pc, #imm]        ; r4 = low bank (offset-corrected)
+            #     it ne ; addne.w r4, #0x1000 ; high bank
+            # 0x468C is alignment padding (verified zero & unreferenced in the
+            # SHA1-pinned stock ROM) within ldr.w +/-4095 range of both sites.
+            offset_size = getattr(self.args, "offset_size", 0) or 0
+            nvram_lo = 0xFE000 + self.ext_offset + offset_size
+            literal_off = 0x468C
+            if self.internal.int(literal_off) != 0:
+                raise RuntimeError(
+                    f"NVRAM literal slot 0x{literal_off:X} is not free "
+                    f"(0x{self.internal.int(literal_off):08X}); stock ROM changed?"
+                )
+            self.internal.replace(literal_off, nvram_lo, size=4)
+            log.debug(f"NVRAM low-bank addr 0x{nvram_lo:X} -> literal 0x{literal_off:X}")
+
             log.debug("Update NVRAM read addresses")
+            imm_r = literal_off - ((0x4856 + 4) & ~3)
             self.internal.asm(
                 0x4856,
-                "ite ne; "
-                f"movne.w r4, #{hex(0xff000 + self.ext_offset)}; "
-                f"moveq.w r4, #{hex(0xfe000 + self.ext_offset)}",
+                f"ldr.w r4, [pc, #{imm_r}]; it ne; addne.w r4, r4, #0x1000",
             )
             log.debug("Update NVRAM write addresses")
+            imm_w = literal_off - ((0x48C0 + 4) & ~3)
             self.internal.asm(
                 0x48C0,
-                "ite ne; "
-                f"movne.w r4, #{hex(0xff000 + self.ext_offset)}; "
-                f"moveq.w r4, #{hex(0xfe000 + self.ext_offset)}",
+                f"ldr.w r4, [pc, #{imm_w}]; it ne; addne.w r4, r4, #0x1000",
             )
 
         # Finally, shorten the firmware
         log.debug("Updating end of OTFDEC pointer")
         self.internal.add(0x1_06EC, self.ext_offset)
         self.external.shorten(self.ext_offset)
+
+        offset_size = getattr(self.args, "offset_size", 0)
+        if offset_size > 0:
+            # We need to increase the OCTOSPI device size configuration so the memory-mapped space covers the offset.
+            # Stock is 20 (1MB).
+            # We calculate the next power of 2 exponent.
+            needed_bytes = offset_size + len(self.external)
+            device_size = (needed_bytes - 1).bit_length()
+            # Ensure it is at least the stock size of 20
+            device_size = max(20, device_size)
+            log.debug(f"Patching OCTOSPI device size to {device_size} (covering up to {1 << device_size} bytes)")
+            self.internal.replace(0xA41E, device_size, size=1)
 
         internal_remaining_free = len(self.internal) - self.int_pos
         compressed_memory_free = (

--- a/gnwmanager/cli/gnw_patch/patch.py
+++ b/gnwmanager/cli/gnw_patch/patch.py
@@ -261,9 +261,10 @@ class FirmwarePatchMixin:
                 else:
                     self.clear_range(old_start, old_end)
 
+        dst_base = self.FLASH_BASE + self._offset
         for i in range(size):
             self._lookup[self.FLASH_BASE + old_start + i] = (
-                self.FLASH_BASE + new_start + i
+                dst_base + new_start + i
             )
 
         return size

--- a/gnwmanager/cli/gnw_patch/zelda.py
+++ b/gnwmanager/cli/gnw_patch/zelda.py
@@ -123,6 +123,14 @@ class ZeldaGnW(Device, name="zelda"):
         self.external.set_range(0x3E_8000, 0x3F_0000, b"\xFF")
 
     def patch(self):
+        if getattr(self.args, "offset_size", 0):
+            raise ValueError(
+                "The Zelda OFW does not support relocating external flash to an offset: "
+                "unlike Mario it has no relocatable base register and reaches its external "
+                "data through absolute 0x90xxxxxx pointers, so the data is fixed at "
+                "0x90000000. Re-run with ext_offset=0."
+            )
+
         b_w_memcpy_inflate_asm = "b.w #" + hex(0xFFFFFFFE & self.internal.address("memcpy_inflate"))
 
         self._erase_savedata()


### PR DESCRIPTION
A new `ext_offset` flag relocates the patched Mario firmware's external data from the 0x90000000 base to 0x90000000 + ext_offset, so the OFW can coexist with other data (e.g. a second OFW) on a large SPI flash.

* _patch.py: `ext_offset` flag on `mario` (int_parser converter; offset bounds are validated downstream by gnw.flash).
* firmware.py / patch.py: the relocation lookup shifts external-flash destinations by a per-firmware `_offset` (set on self.external in __call__); both move/copy paths use FLASH_BASE + _offset.
* mario.py: repoint the memory-mapped read base, grow the OCTOSPI device size to span the offset, and offset the NVRAM save address. That last part is required for correctness: without it the save targets the un-offset 0xfe000+ext_offset (e.g. 0xd9000), which lands in the other console's external region and corrupts it.

Zelda cannot support this. It has no relocatable base register and reaches its external data through absolute pointers, so its data is fixed at 0x90000000. The `zelda` command accepts `ext_offset` for parity but rejects any nonzero value with a clear ValueError.