### PR TITLE
More robust transfers

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -54,3 +56,12 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - name: Upload binaries to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            gnwmanager/firmware.bin
+            gnwmanager/unlock.bin
+            dist/*

--- a/Core/Inc/gnwmanager.h
+++ b/Core/Inc/gnwmanager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdbool.h>
 #include <stdint.h>
 
 enum gnwmanager_status { // For signaling program status to computer
@@ -30,3 +31,7 @@ typedef uint32_t gnwmanager_status_t;  // All computer interactions are uint32_t
 
 void gnwmanager_main(gnwmanager_status_t status);
 void gnwmanager_set_status(gnwmanager_status_t status);
+
+// True only when the device is fully idle: status is IDLE, no contexts queued
+// by the host, and no host upload/download in flight.
+bool gnwmanager_is_idle(void);

--- a/Core/Inc/gnwmanager.h
+++ b/Core/Inc/gnwmanager.h
@@ -17,6 +17,7 @@ enum gnwmanager_status { // For signaling program status to computer
     GNWMANAGER_STATUS_BAD_SD_DIR      = 0xbad0000b,
     GNWMANAGER_STATUS_BAD_SD_LIST_TRUNC = 0xbad0000c,
     GNWMANAGER_STATUS_BAD_SD_READ       = 0xbad0000d,
+    GNWMANAGER_STATUS_BAD_HASH_RAM_COMPRESSED = 0xbad0000e,
 
     GNWMANAGER_STATUS_IDLE            = 0xcafe0000,
     GNWMANAGER_STATUS_ERASE     ,

--- a/Core/Inc/rg_rtc.h
+++ b/Core/Inc/rg_rtc.h
@@ -5,41 +5,13 @@
 extern "C" {
 #endif
 
-/* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_hal.h"
 #include <time.h>
 
-/* Exported constants --------------------------------------------------------*/
 extern RTC_TimeTypeDef GW_currentTime;
 extern RTC_DateTypeDef GW_currentDate;
-extern const char * GW_RTC_Weekday[];
-
-/* Exported functions prototypes ---------------------------------------------*/
-
-// Getters
-uint8_t GW_GetCurrentHour(void);
-uint8_t GW_GetCurrentMinute(void);
-uint8_t GW_GetCurrentSecond(void);
-
-uint8_t GW_GetCurrentMonth(void);
-uint8_t GW_GetCurrentDay(void);
-
-uint8_t GW_GetCurrentWeekday(void);
-uint8_t GW_GetCurrentYear(void);
 
 time_t GW_GetUnixTime(void);
-
-// Setters
-void GW_SetCurrentHour(const uint8_t hour);
-void GW_SetCurrentMinute(const uint8_t minute);
-void GW_SetCurrentSecond(const uint8_t second);
-
-void GW_SetCurrentMonth(const uint8_t month);
-void GW_SetCurrentDay(const uint8_t day);
-
-void GW_SetCurrentWeekday(const uint8_t weekday);
-void GW_SetCurrentYear(const uint8_t year);
-
 void GW_SetUnixTime(uint32_t time);
 
 #ifdef __cplusplus

--- a/Core/Src/FatFs/user_diskio.c
+++ b/Core/Src/FatFs/user_diskio.c
@@ -35,7 +35,6 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include <string.h>
-#include <time.h>
 #include "main.h"
 #include "ff.h"
 #include "user_diskio_spi.h"
@@ -229,19 +228,17 @@ DRESULT disk_ioctl (
 
 DWORD get_fattime (void)
 {
-    time_t t;
-    struct tm *stm;
+    // RTC is UTC; FAT stores wall-clock fields directly, so read the RTC
+    // straight through instead of round-tripping via Unix time + localtime().
+    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
+    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
 
-
-    t = GW_GetUnixTime();
-    stm = localtime(&t);
-
-    return (DWORD)(stm->tm_year - 80) << 25 |
-           (DWORD)(stm->tm_mon + 1) << 21 |
-           (DWORD)stm->tm_mday << 16 |
-           (DWORD)stm->tm_hour << 11 |
-           (DWORD)stm->tm_min << 5 |
-           (DWORD)stm->tm_sec >> 1;
+    return ((DWORD)(2000 + GW_currentDate.Year - 1980) << 25) |
+           ((DWORD)GW_currentDate.Month << 21) |
+           ((DWORD)GW_currentDate.Date << 16) |
+           ((DWORD)GW_currentTime.Hours << 11) |
+           ((DWORD)GW_currentTime.Minutes << 5) |
+           ((DWORD)GW_currentTime.Seconds >> 1);
 }
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Core/Src/FatFs/user_diskio_softspi.c
+++ b/Core/Src/FatFs/user_diskio_softspi.c
@@ -262,7 +262,12 @@ static void finish_read_cmd(void)
     SoftSpi_WriteDummyRead(sd.spi, NULL, 2);
 }
 
-static bool finish_write_cmd(void)
+/* Returns the SD data response token status (low 5 bits):
+ *   0x05 = accepted
+ *   0x0B = CRC error (recoverable)
+ *   0x0D = write error (fatal)
+ */
+static uint8_t finish_write_cmd(void)
 {
     uint8_t rbyte;
 
@@ -276,10 +281,7 @@ static bool finish_write_cmd(void)
         SoftSpi_WriteDummyRead(sd.spi, &rbyte, 1);
     } while (rbyte == 0xFF); // Fix : add timeout
 
-    if ((rbyte & 0xF) != 0x05)
-    {
-        return false;
-    }
+    uint8_t status = rbyte & 0x1F;
 
     // Wait for data to be written
     do
@@ -287,7 +289,7 @@ static bool finish_write_cmd(void)
         SoftSpi_WriteDummyRead(sd.spi, &rbyte, 1);
     } while (rbyte == 0x00); // Fix : add timeout
 
-    return true;
+    return status;
 }
 
 //-----[ SD Card Functions ]-----
@@ -581,25 +583,10 @@ DRESULT USER_SOFTSPI_write(
 
     if (count == 1)
     {
-        /* WRITE_SINGLE_BLOCK */
-        do
-        {
-            response = send_cmd(WRITE_SINGLE_BLOCK, sector);
-        } while (response.r0);
-
-        // Send dummy pre-send byte and start block token
-        SoftSpi_WriteDummyRead(sd.spi, NULL, 1);
-        SoftSpi_WriteRead(sd.spi, &start_block_token, NULL, 1);
-
-        SoftSpi_WriteRead(sd.spi, buff, NULL, BLOCK_SIZE);
-
-        if (finish_write_cmd()) {
-            count = 0;
-        }
-    }
-    else
-    {
-        do
+        /* WRITE_SINGLE_BLOCK with retries on transient CRC errors. CMD24
+         * carries the sector address, so re-issuing the whole sequence is
+         * always safe. */
+        for (uint8_t attempt = 0; attempt < 3; attempt++)
         {
             do
             {
@@ -612,9 +599,35 @@ DRESULT USER_SOFTSPI_write(
 
             SoftSpi_WriteRead(sd.spi, buff, NULL, BLOCK_SIZE);
 
-            if(!finish_write_cmd()) {
-                break;
+            uint8_t status = finish_write_cmd();
+            if (status == 0x05) { count = 0; break; }
+            if (status == 0x0D) break; /* card-reported write error: not recoverable */
+        }
+    }
+    else
+    {
+        do
+        {
+            uint8_t status = 0;
+            for (uint8_t attempt = 0; attempt < 3; attempt++)
+            {
+                do
+                {
+                    response = send_cmd(WRITE_SINGLE_BLOCK, sector);
+                } while (response.r0);
+
+                // Send dummy pre-send byte and start block token
+                SoftSpi_WriteDummyRead(sd.spi, NULL, 1);
+                SoftSpi_WriteRead(sd.spi, &start_block_token, NULL, 1);
+
+                SoftSpi_WriteRead(sd.spi, buff, NULL, BLOCK_SIZE);
+
+                status = finish_write_cmd();
+                /* Single-block writes carry their own address, so any
+                 * non-fatal failure is safe to retry. */
+                if (status == 0x05 || status == 0x0D) break;
             }
+            if (status != 0x05) break;
 
             buff += BLOCK_SIZE;
             if (!(CardType & CT_BLOCK))

--- a/Core/Src/FatFs/user_diskio_spi.c
+++ b/Core/Src/FatFs/user_diskio_spi.c
@@ -181,41 +181,41 @@ static bool SD_RxDataBlock(BYTE *buff, UINT len)
     return TRUE;
 }
 
-/* transmit data block */
-static bool SD_TxDataBlock(const uint8_t *buff, BYTE token)
+/* transmit data block; returns the SD data response token status (low 5 bits):
+ *   0x05 = accepted
+ *   0x0B = CRC error (recoverable: card discards block, stays in receive state)
+ *   0x0D = write error (fatal: card rejected block, abort with STOP_TRAN)
+ *   0xFF = no valid response / card not ready
+ */
+static uint8_t SD_TxDataBlock(const uint8_t *buff, BYTE token)
 {
-    uint8_t resp = 0;
-    uint8_t i = 0;
+    uint8_t resp;
     /* wait SD ready */
     if (SD_ReadyWait() != 0xFF)
-        return FALSE;
+        return 0xFF;
     /* transmit token */
     SPI_TxByte(token);
-    /* if it's not STOP_TRAN token, transmit data and wait for response */
-    if (token != 0xFD)
-    {
-        SPI_TxBuffer((uint8_t *)buff, 512);
-        /* discard CRC */
-        SPI_RxByte();
-        SPI_RxByte();
-        /* receive response (max 65 bytes) */
-        while (i <= 64)
-        {
-            resp = SPI_RxByte();
-            if ((resp & 0x1F) == 0x05)
-                break;
-            i++;
-        }
-        /* clear remaining response bytes (max 64 to avoid infinite loop) */
-        for (i = 0; i < 64 && SPI_RxByte() == 0; i++)
-            ;
+    /* STOP_TRAN has no data + response; just wait for card to leave busy. */
+    if (token == 0xFD)
+        return (SD_ReadyWait() == 0xFF) ? 0x05 : 0xFF;
+    SPI_TxBuffer((uint8_t *)buff, 512);
+    /* discard CRC */
+    SPI_RxByte();
+    SPI_RxByte();
+    /* The data response token has shape xxx0sss1 and follows within a byte or two
+     * (spec: 1 byte). Scan up to 8 bytes for a token-shaped response. */
+    resp = 0xFF;
+    for (uint8_t i = 0; i < 8; i++) {
+        resp = SPI_RxByte();
+        if ((resp & 0x11) == 0x01)
+            break;
     }
-    else
-    {
-        /* STOP_TRAN: wait for card to leave busy state */
-        return (SD_ReadyWait() == 0xFF);
-    }
-    return (resp & 0x1F) == 0x05;
+    if ((resp & 0x11) != 0x01)
+        return 0xFF;
+    /* Card holds MISO low while programming; wait until it releases the bus.
+     * Some cards stay busy 100ms+ during garbage collection. */
+    SD_ReadyWait();
+    return resp & 0x1F;
 }
 
 /* transmit command */
@@ -464,25 +464,44 @@ DRESULT USER_SPI_write(
 
     if (count == 1)
     {
-        /* WRITE_BLOCK */
-        if ((SD_SendCmd(CMD24, sector) == 0) && SD_TxDataBlock(buff, 0xFE))
-            count = 0;
+        /* WRITE_BLOCK with retries on transient CRC errors. CMD24 carries the
+         * sector address, so re-issuing the whole sequence is always safe. */
+        for (uint8_t attempt = 0; attempt < 3; attempt++)
+        {
+            if (SD_SendCmd(CMD24, sector) != 0)
+                continue;
+            uint8_t status = SD_TxDataBlock(buff, 0xFE);
+            if (status == 0x05) { count = 0; break; }
+            if (status == 0x0D) break; /* card-reported write error: not recoverable */
+        }
     }
     else
     {
         /* WRITE_MULTIPLE_BLOCK */
         if (CardType & CT_SDC)
         {
-            SD_SendCmd(CMD55, 0);
-            SD_SendCmd(CMD23, count); /* ACMD23 */
+            /* ACMD23 pre-erase: only fire CMD23 if CMD55 was accepted, so a card
+             * that rejects ACMD55 doesn't leave the bus mid-handshake. */
+            if (SD_SendCmd(CMD55, 0) <= 1)
+                SD_SendCmd(CMD23, count);
         }
 
         if (SD_SendCmd(CMD25, sector) == 0)
         {
             do
             {
-                if (!SD_TxDataBlock(buff, 0xFC))
-                    break;
+                /* Per spec, CRC errors during multi-block write leave the card
+                 * in receive state at the same auto-incrementing address, so the
+                 * same block can be retransmitted safely. Other failures
+                 * (write error, no response) leave the card state ambiguous —
+                 * abort to STOP_TRAN rather than risk a misaligned retry. */
+                uint8_t status = 0;
+                for (uint8_t attempt = 0; attempt < 3; attempt++)
+                {
+                    status = SD_TxDataBlock(buff, 0xFC);
+                    if (status != 0x0B) break;
+                }
+                if (status != 0x05) break;
                 buff += 512;
             } while (--count);
 

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -801,7 +801,7 @@ static void gnwmanager_run(void)
 
 void gnwmanager_main(gnwmanager_status_t status)
 {
-    uint8_t power_was_pressed = ((buttons_get() & B_POWER) != 0);
+    uint8_t reset_was_pressed = ((buttons_get() & (B_POWER | B_B)) != 0);
 
     memset((void *)&comm, 0, sizeof(comm));
     comm.status = status;
@@ -818,11 +818,11 @@ void gnwmanager_main(gnwmanager_status_t status)
         // Error happened during system setup.
         gnwmanager_gui_draw();
         while(true){
-            uint8_t power_pressed = ((buttons_get() & B_POWER) != 0);
-            if((!power_was_pressed) && power_pressed){
+            uint8_t reset_pressed = ((buttons_get() & (B_POWER | B_B)) != 0);
+            if((!reset_was_pressed) && reset_pressed){
                 NVIC_SystemReset();
             }
-            power_was_pressed = power_pressed;
+            reset_was_pressed = reset_pressed;
             wdog_refresh();
         }
     }
@@ -833,11 +833,11 @@ void gnwmanager_main(gnwmanager_status_t status)
 
 
     while (true) {
-        uint8_t power_pressed = ((buttons_get() & B_POWER) != 0);
-        if((!power_was_pressed) && power_pressed){
+        uint8_t reset_pressed = ((buttons_get() & (B_POWER | B_B)) != 0);
+        if((!reset_was_pressed) && reset_pressed){
             NVIC_SystemReset();
         }
-        power_was_pressed = power_pressed;
+        reset_was_pressed = reset_pressed;
 
         if(comm.status_override){
             gui.status = &comm.status_override;

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -717,6 +717,9 @@ static void gnwmanager_run(void)
                 // This is first block, open file
                 res = f_open(&file, (const char *)working_context->file_path, FA_WRITE | FA_CREATE_ALWAYS);
                 if (res != FR_OK) {
+                    /* Unmount so the next attempt re-mounts cleanly; otherwise
+                     * FATFS retains stale state from this failed open. */
+                    f_mount(NULL, "", 0);
                     gnwmanager_set_status(GNWMANAGER_STATUS_BAD_SD_OPEN);
                     state = GNWMANAGER_ERROR;
                     break;
@@ -725,6 +728,11 @@ static void gnwmanager_run(void)
             if (working_context->size > 0) {
                 res = f_write(&file, (const void *)working_context->buffer, working_context->size, &bytes_written);
                 if (res != FR_OK || bytes_written < working_context->size) {
+                    /* Close + unmount so the half-written file's directory entry
+                     * is at least finalized, and the next sdpush starts from a
+                     * clean FATFS/FIL state. */
+                    f_close(&file);
+                    f_mount(NULL, "", 0);
                     gnwmanager_set_status(GNWMANAGER_STATUS_BAD_SD_WRITE);
                     state = GNWMANAGER_ERROR;
                     break;

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -88,6 +88,9 @@ typedef struct {
             // total blocks for file
             uint32_t total_blocks;
 
+            // sha256 of the bytes the host placed in `buffer`. All-zero = skip check.
+            uint8_t compressed_sha256[32];
+
             /* Add future variables here */
 
             // This work context is ready for the on-device gnwmanager to process.
@@ -604,6 +607,33 @@ static void gnwmanager_run(void)
     case GNWMANAGER_DECOMPRESSING:
     case GNWMANAGER_DECOMPRESSING_SD:
         if(working_context->compressed_size){
+            // If the host populated compressed_sha256, verify the compressed bytes
+            // match before LZMA touches them, so a transfer/cache corruption surfaces
+            // as BAD_HASH_RAM rather than the more confusing BAD_DECOMPRESS.
+            // All-zero = host didn't populate; skip.
+            uint8_t expected_or = 0;
+            for(int k = 0; k < 32; k++){
+                expected_or |= working_context->compressed_sha256[k];
+            }
+            if(expected_or){
+                if(HAL_HASHEx_SHA256_Start(&hhash,
+                    (uint8_t *)working_context->buffer, working_context->compressed_size,
+                    program_calculated_sha256,
+                    HAL_MAX_DELAY
+                )){
+                    Error_Handler();
+                }
+                if(memcmp((const void *)program_calculated_sha256,
+                          (const void *)working_context->compressed_sha256, 32) != 0){
+                    memcpy((void *)comm.actual_hash, program_calculated_sha256, 32);
+                    memcpy((void *)comm.expected_hash,
+                           (void *)working_context->compressed_sha256, 32);
+                    gnwmanager_set_status(GNWMANAGER_STATUS_BAD_HASH_RAM);
+                    state = GNWMANAGER_ERROR;
+                    break;
+                }
+            }
+
             // Decompress the data; nothing after this state should reference decompression.
             uint32_t n_decomp_bytes;
             n_decomp_bytes = lzma_inflate(comm.decompress_buffer, sizeof(comm.decompress_buffer),

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -326,7 +326,11 @@ static void gnwmanager_action_list_sd_dir(work_context_t *context){
         if (name[0] == '.' && name[1] == '.' && name[2] == 0) {
             continue;
         }
-        if (used >= cap) {
+        // Inlined "%s%s\n" formatting — keeps the entire newlib nano-vfprintf
+        // stack out of the firmware (~1.7KB saved).
+        const uint32_t name_len = (uint32_t)strlen(name);
+        const uint32_t suffix_len = (fno.fattrib & AM_DIR) ? 2u : 1u;  // '/'+'\n' or just '\n'
+        if (name_len + suffix_len > cap - used) {
             gnwmanager_set_status(GNWMANAGER_STATUS_BAD_SD_LIST_TRUNC);
             f_closedir(&dir);
             f_mount(NULL, "", 0);
@@ -334,17 +338,12 @@ static void gnwmanager_action_list_sd_dir(work_context_t *context){
             context->response_ready = 1;
             return;
         }
-        int n = snprintf((char *)out + used, cap - used, "%s%s\n", name,
-                         (fno.fattrib & AM_DIR) ? "/" : "");
-        if (n < 0 || (uint32_t)n >= cap - used) {
-            gnwmanager_set_status(GNWMANAGER_STATUS_BAD_SD_LIST_TRUNC);
-            f_closedir(&dir);
-            f_mount(NULL, "", 0);
-            context->size = used;
-            context->response_ready = 1;
-            return;
+        memcpy(out + used, name, name_len);
+        used += name_len;
+        if (fno.fattrib & AM_DIR) {
+            out[used++] = '/';
         }
-        used += (uint32_t)n;
+        out[used++] = '\n';
     }
 
     f_closedir(&dir);

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -627,7 +627,7 @@ static void gnwmanager_run(void)
                     memcpy((void *)comm.actual_hash, program_calculated_sha256, 32);
                     memcpy((void *)comm.expected_hash,
                            (void *)working_context->compressed_sha256, 32);
-                    gnwmanager_set_status(GNWMANAGER_STATUS_BAD_HASH_RAM);
+                    gnwmanager_set_status(GNWMANAGER_STATUS_BAD_HASH_RAM_COMPRESSED);
                     state = GNWMANAGER_ERROR;
                     break;
                 }

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -267,6 +267,14 @@ static void release_context(work_context_t *context){
     memset((void *)context, 0, sizeof(work_context_t));
 }
 
+bool gnwmanager_is_idle(void){
+    return comm.status == GNWMANAGER_STATUS_IDLE
+        && comm.contexts[0].ready == 0
+        && comm.contexts[1].ready == 0
+        && !comm.upload_in_progress
+        && !comm.download_in_progress;
+}
+
 void gnwmanager_set_status(gnwmanager_status_t status){
     static gnwmanager_status_t prev_status = 0;
     comm.status = status;
@@ -878,10 +886,7 @@ void gnwmanager_main(gnwmanager_status_t status)
 
     while (true) {
         uint8_t reset_pressed = ((buttons_get() & (B_POWER | B_B)) != 0);
-        uint8_t truly_idle = (comm.status == GNWMANAGER_STATUS_IDLE)
-                          && !comm.upload_in_progress
-                          && !comm.download_in_progress;
-        if((!reset_was_pressed) && reset_pressed && truly_idle){
+        if((!reset_was_pressed) && reset_pressed && gnwmanager_is_idle()){
             NVIC_SystemReset();
         }
         reset_was_pressed = reset_pressed;

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -878,7 +878,10 @@ void gnwmanager_main(gnwmanager_status_t status)
 
     while (true) {
         uint8_t reset_pressed = ((buttons_get() & (B_POWER | B_B)) != 0);
-        if((!reset_was_pressed) && reset_pressed){
+        uint8_t truly_idle = (comm.status == GNWMANAGER_STATUS_IDLE)
+                          && !comm.upload_in_progress
+                          && !comm.download_in_progress;
+        if((!reset_was_pressed) && reset_pressed && truly_idle){
             NVIC_SystemReset();
         }
         reset_was_pressed = reset_pressed;

--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -31,6 +31,7 @@ typedef enum {  // For the gnwmanager state machine
     GNWMANAGER_DECOMPRESSING_SD       ,
     GNWMANAGER_CHECK_HASH_RAM_SD      ,
     GNWMANAGER_PROGRAM_SD             ,
+    GNWMANAGER_HASH_RETRY_WAIT        ,  // Wait for host to re-transmit a buffer after BAD_HASH_RAM_COMPRESSED
 
     GNWMANAGER_ERROR = 0xF000,
 } gnwmanager_state_t;
@@ -134,6 +135,15 @@ struct gnwmanager_comm {  // Values are read or written by the debugger
             uint8_t expected_hash[32];
 
             uint8_t actual_hash[32];
+
+            // Retry handshake: when the device detects BAD_HASH_RAM_COMPRESSED it
+            // writes the failed context index here, transitions to HASH_RETRY_WAIT,
+            // and waits for the host to (a) re-transmit the data into the same
+            // context buffer and (b) bump retry_request. The device then echoes
+            // retry_request into retry_ack and re-runs the hash check.
+            uint32_t failed_context_idx;  // output: which comm.buffer[i] needs re-transmit
+            uint32_t retry_request;       // input: host increments to request a retry
+            uint32_t retry_ack;           // output: device echoes after consuming retry_request
         };
         struct {
             // Force spacing, allowing for backward-compatible additional variables
@@ -627,8 +637,14 @@ static void gnwmanager_run(void)
                     memcpy((void *)comm.actual_hash, program_calculated_sha256, 32);
                     memcpy((void *)comm.expected_hash,
                            (void *)working_context->compressed_sha256, 32);
+                    /* Publish which comm.buffer[i] needs re-transmit BEFORE
+                     * setting status: the host reads status first and uses
+                     * failed_context_idx to drive the retry. source_context
+                     * is still valid here — release_context() runs further
+                     * down on the success path. */
+                    comm.failed_context_idx = (uint32_t)(source_context - &comm.contexts[0]);
                     gnwmanager_set_status(GNWMANAGER_STATUS_BAD_HASH_RAM_COMPRESSED);
-                    state = GNWMANAGER_ERROR;
+                    state = GNWMANAGER_HASH_RETRY_WAIT;
                     break;
                 }
             }
@@ -796,6 +812,26 @@ static void gnwmanager_run(void)
         }
         // Hash OK in FLASH
         state = GNWMANAGER_IDLE;
+        break;
+    case GNWMANAGER_HASH_RETRY_WAIT:
+        /* Park until the host bumps retry_request. The host has by then
+         * re-transmitted the source buffer (and compressed_sha256) into the
+         * same comm.contexts[failed_context_idx] / comm.buffer[failed_context_idx].
+         * Re-sync working_context from source_context and re-enter
+         * DECOMPRESSING_* to re-run the compressed-hash check. */
+        if (comm.retry_request != comm.retry_ack) {
+            memcpy((void *)working_context, (void *)source_context, sizeof(work_context_t));
+            /* Clear BAD status so the GUI doesn't get stuck showing the error
+             * across retries. The host polls retry_ack to know the retry was
+             * consumed, so update status first to ensure that when the host
+             * sees retry_ack == retry_request, the post-retry status is
+             * already visible (no stale BAD read). */
+            gnwmanager_set_status(GNWMANAGER_STATUS_HASH);
+            state = (source_context->action == GNWMANAGER_ACTION_WRITE_FILE_TO_SD)
+                  ? GNWMANAGER_DECOMPRESSING_SD
+                  : GNWMANAGER_DECOMPRESSING;
+            comm.retry_ack = comm.retry_request;
+        }
         break;
     case GNWMANAGER_ERROR:
         /* Allow a new host command after release_context() cleared ready bits. */

--- a/Core/Src/gnwmanager_gui.c
+++ b/Core/Src/gnwmanager_gui.c
@@ -137,7 +137,7 @@ void gnwmanager_gui_draw(){
         gui.run_state = IS_RUNNING ? (gui.run_state + 1) % 10 : 0;
     }
 
-    DRAW(10, 16, &img_idle, *gui.status == GNWMANAGER_STATUS_IDLE);
+    DRAW(10, 16, &img_idle, *gui.status == GNWMANAGER_STATUS_IDLE && !*gui.download_in_progress && !*gui.upload_in_progress);
     DRAW(54, 16, &img_prog, *gui.status == GNWMANAGER_STATUS_PROG);
     DRAW(10, 37, &img_erase, *gui.status == GNWMANAGER_STATUS_ERASE);
 

--- a/Core/Src/gnwmanager_gui.c
+++ b/Core/Src/gnwmanager_gui.c
@@ -66,7 +66,9 @@ void gui_draw_glyph(uint16_t x_pos, uint16_t y_pos, const glyph_t *glyph, pixel_
 #define IS_ERROR_STATUS ((*gui.status & 0xFFFF0000) == 0xbad00000)
 #define SLEEPING_THRESH 5
 #define IS_SLEEPING (gui.counter_to_sleep == SLEEPING_THRESH)
-#define IS_RUNNING (!IS_SLEEPING && !IS_ERROR_STATUS)
+// Walking animation only when the device is actually doing work; "truly idle"
+// (no queued contexts, no host transfer) shows the IDLE icon instead.
+#define IS_BUSY (!gnwmanager_is_idle() && !IS_ERROR_STATUS)
 
 gnwmanager_gui_t gui;
 
@@ -125,19 +127,21 @@ void gnwmanager_gui_draw(){
         prev_status = *gui.status;
     }
 
-    if(*gui.status != GNWMANAGER_STATUS_IDLE || *gui.download_in_progress || *gui.upload_in_progress){
+    bool truly_idle = gnwmanager_is_idle();
+
+    if(!truly_idle){
         gui.counter_to_sleep = 0;
     }
 
     if(step){
-        if(!IS_SLEEPING && *gui.status == GNWMANAGER_STATUS_IDLE)
+        if(!IS_SLEEPING && truly_idle)
             gui.counter_to_sleep++;
 
         gui.sleep_z_state = IS_SLEEPING ? (gui.sleep_z_state + 1) % 4 : 0;
-        gui.run_state = IS_RUNNING ? (gui.run_state + 1) % 10 : 0;
+        gui.run_state = IS_BUSY ? (gui.run_state + 1) % 10 : 0;
     }
 
-    DRAW(10, 16, &img_idle, *gui.status == GNWMANAGER_STATUS_IDLE && !*gui.download_in_progress && !*gui.upload_in_progress);
+    DRAW(10, 16, &img_idle, truly_idle);
     DRAW(54, 16, &img_prog, *gui.status == GNWMANAGER_STATUS_PROG);
     DRAW(10, 37, &img_erase, *gui.status == GNWMANAGER_STATUS_ERASE);
 
@@ -190,7 +194,7 @@ void gnwmanager_gui_draw(){
     };
     for(uint8_t i=0; i<10; i++){
         DRAW(RUN_ORIGIN_X + i * RUN_SPACING, RUN_ORIGIN_Y, run[i],
-                (i == gui.run_state) && IS_RUNNING);
+                (i == gui.run_state) && IS_BUSY);
     }
 
     const glyph_t* progress[] = {

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1101,6 +1101,15 @@ void Error_Handler(void)
   /* USER CODE END Error_Handler_Debug */
 }
 
+// Override newlib's __assert_func so failed assert()s don't drag the entire
+// nano-vfprintf chain (~1.5KB) into the firmware via fiprintf(stderr,...).
+// Args are dropped because stderr writes go nowhere on this device anyway.
+void __assert_func(const char *file, int line, const char *func, const char *failedexpr)
+{
+  (void)file; (void)line; (void)func; (void)failedexpr;
+  Error_Handler();
+}
+
 void HAL_Delay(uint32_t Delay)
 {
   while (Delay--) {

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1073,7 +1073,7 @@ void MPU_Config(void)
   MPU_InitStruct.SubRegionDisable = 0x0;
   MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
   MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;
-  MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_DISABLE;
+  MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_ENABLE;
   MPU_InitStruct.IsShareable = MPU_ACCESS_NOT_SHAREABLE;
   MPU_InitStruct.IsCacheable = MPU_ACCESS_NOT_CACHEABLE;
   MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1069,7 +1069,7 @@ void MPU_Config(void)
   MPU_InitStruct.Enable = MPU_REGION_ENABLE;
   MPU_InitStruct.Number = MPU_REGION_NUMBER1;
   MPU_InitStruct.BaseAddress = 0x24000000;
-  MPU_InitStruct.Size = MPU_REGION_SIZE_512KB;
+  MPU_InitStruct.Size = MPU_REGION_SIZE_1MB;
   MPU_InitStruct.SubRegionDisable = 0x0;
   MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
   MPU_InitStruct.AccessPermission = MPU_REGION_FULL_ACCESS;

--- a/Core/Src/rg_rtc.c
+++ b/Core/Src/rg_rtc.c
@@ -167,41 +167,59 @@ void GW_SetCurrentYear(const uint8_t year) {
     }
 }
 
+// Howard Hinnant's days_from_civil / civil_from_days. UTC only, no DST/tz —
+// replaces newlib mktime/gmtime which otherwise drag in ~2.4KB of tz code.
+static int32_t days_from_civil(int y, unsigned m, unsigned d) {
+    y -= m <= 2;
+    const int era = y / 400;
+    const unsigned yoe = (unsigned)(y - era * 400);
+    const unsigned doy = (153u * (m > 2 ? m - 3u : m + 9u) + 2u) / 5u + d - 1u;
+    const unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+    return era * 146097 + (int32_t)doe - 719468;
+}
+
+static void civil_from_days(int32_t z, int *y, unsigned *m, unsigned *d) {
+    z += 719468;
+    const int era = (z >= 0 ? z : z - 146096) / 146097;
+    const unsigned doe = (unsigned)(z - era * 146097);
+    const unsigned yoe = (doe - doe / 1460u + doe / 36524u - doe / 146096u) / 365u;
+    const unsigned doy = doe - (365u * yoe + yoe / 4u - yoe / 100u);
+    const unsigned mp = (5u * doy + 2u) / 153u;
+    *d = doy - (153u * mp + 2u) / 5u + 1u;
+    *m = mp < 10u ? mp + 3u : mp - 9u;
+    *y = (int)yoe + era * 400 + (*m <= 2);
+}
+
 time_t GW_GetUnixTime(void) {
-    // Function to return Unix timestamp since 1st Jan 1970.
-    // The time is returned as an 64-bit value, but only the top 32-bits are populated.
-
-    time_t timestamp;
-    struct tm timeStruct;
-
     HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
 
-    timeStruct.tm_year = GW_currentDate.Year + 100;  // tm_year base is 1900, RTC can only save 0 - 99, so bump to 2000.
-    timeStruct.tm_mday = GW_currentDate.Date;
-    timeStruct.tm_mon  = GW_currentDate.Month - 1;
-
-    timeStruct.tm_hour = GW_currentTime.Hours;
-    timeStruct.tm_min  = GW_currentTime.Minutes;
-    timeStruct.tm_sec  = GW_currentTime.Seconds;
-
-    timestamp = mktime(&timeStruct);
-
-    return timestamp;
+    int32_t days = days_from_civil(2000 + GW_currentDate.Year,
+                                   GW_currentDate.Month,
+                                   GW_currentDate.Date);
+    return (time_t)days * 86400
+         + (time_t)GW_currentTime.Hours * 3600
+         + (time_t)GW_currentTime.Minutes * 60
+         + (time_t)GW_currentTime.Seconds;
 }
 
 void GW_SetUnixTime(uint32_t time){
-    struct tm *timeStruct;
-    const int64_t time_64 = time;
-    timeStruct = gmtime(&time_64);
+    int32_t days = (int32_t)(time / 86400u);
+    uint32_t tod = time % 86400u;
+    int year;
+    unsigned month, day;
+    civil_from_days(days, &year, &month, &day);
 
-    GW_SetCurrentYear(timeStruct->tm_year - 100);
-    GW_SetCurrentMonth(timeStruct->tm_mon + 1);
-    GW_SetCurrentDay(timeStruct->tm_mday);
+    // RTC weekday: 1=Mon..7=Sun. 1970-01-01 is a Thursday (days=0 -> 4).
+    int weekday = (int)(((unsigned)(days + 3) % 7u) + 1u);
 
-    GW_SetCurrentHour(timeStruct->tm_hour);
-    GW_SetCurrentMinute(timeStruct->tm_min);
-    GW_SetCurrentSecond(timeStruct->tm_sec);
+    GW_SetCurrentYear((uint8_t)(year - 2000));
+    GW_SetCurrentMonth((uint8_t)month);
+    GW_SetCurrentDay((uint8_t)day);
 
-    GW_SetCurrentWeekday(timeStruct->tm_wday ? timeStruct->tm_wday : 7);
+    GW_SetCurrentHour((uint8_t)(tod / 3600u));
+    GW_SetCurrentMinute((uint8_t)((tod / 60u) % 60u));
+    GW_SetCurrentSecond((uint8_t)(tod % 60u));
+
+    GW_SetCurrentWeekday((uint8_t)weekday);
 }

--- a/Core/Src/rg_rtc.c
+++ b/Core/Src/rg_rtc.c
@@ -6,167 +6,6 @@
 RTC_TimeTypeDef GW_currentTime = {0};
 RTC_DateTypeDef GW_currentDate = {0};
 
-// Getters
-uint8_t GW_GetCurrentHour(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentTime.Hours;
-
-}
-uint8_t GW_GetCurrentMinute(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentTime.Minutes;
-}
-uint8_t GW_GetCurrentSecond(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentTime.Seconds;
-}
-
-uint8_t GW_GetCurrentMonth(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Month;
-}
-uint8_t GW_GetCurrentDay(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Date;
-}
-
-uint8_t GW_GetCurrentWeekday(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.WeekDay;
-}
-uint8_t GW_GetCurrentYear(void) {
-
-    // Get time. According to STM docs, both functions need to be called at once.
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    return GW_currentDate.Year;
-}
-
-// Setters
-void GW_SetCurrentHour(const uint8_t hour) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set time
-    GW_currentTime.Hours = hour;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-void GW_SetCurrentMinute(const uint8_t minute) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set time
-    GW_currentTime.Minutes = minute;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentSecond(const uint8_t second) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set time
-    GW_currentTime.Seconds = second;
-    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentMonth(const uint8_t month) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Month = month;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-void GW_SetCurrentDay(const uint8_t day) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Date = day;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
-void GW_SetCurrentWeekday(const uint8_t weekday) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.WeekDay = weekday;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-void GW_SetCurrentYear(const uint8_t year) {
-
-    // Update time before we can set it
-    HAL_RTC_GetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN);
-    HAL_RTC_GetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN);
-
-    // Set date
-    GW_currentDate.Year = year;
-
-    if (HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
-    {
-        Error_Handler();
-    }
-}
-
 // Howard Hinnant's days_from_civil / civil_from_days. UTC only, no DST/tz —
 // replaces newlib mktime/gmtime which otherwise drag in ~2.4KB of tz code.
 static int32_t days_from_civil(int y, unsigned m, unsigned d) {
@@ -203,7 +42,7 @@ time_t GW_GetUnixTime(void) {
          + (time_t)GW_currentTime.Seconds;
 }
 
-void GW_SetUnixTime(uint32_t time){
+void GW_SetUnixTime(uint32_t time) {
     int32_t days = (int32_t)(time / 86400u);
     uint32_t tod = time % 86400u;
     int year;
@@ -211,15 +50,18 @@ void GW_SetUnixTime(uint32_t time){
     civil_from_days(days, &year, &month, &day);
 
     // RTC weekday: 1=Mon..7=Sun. 1970-01-01 is a Thursday (days=0 -> 4).
-    int weekday = (int)(((unsigned)(days + 3) % 7u) + 1u);
+    GW_currentDate.WeekDay = (uint8_t)(((unsigned)(days + 3) % 7u) + 1u);
+    GW_currentDate.Year    = (uint8_t)(year - 2000);
+    GW_currentDate.Month   = (uint8_t)month;
+    GW_currentDate.Date    = (uint8_t)day;
 
-    GW_SetCurrentYear((uint8_t)(year - 2000));
-    GW_SetCurrentMonth((uint8_t)month);
-    GW_SetCurrentDay((uint8_t)day);
+    GW_currentTime.Hours   = (uint8_t)(tod / 3600u);
+    GW_currentTime.Minutes = (uint8_t)((tod / 60u) % 60u);
+    GW_currentTime.Seconds = (uint8_t)(tod % 60u);
 
-    GW_SetCurrentHour((uint8_t)(tod / 3600u));
-    GW_SetCurrentMinute((uint8_t)((tod / 60u) % 60u));
-    GW_SetCurrentSecond((uint8_t)(tod % 60u));
-
-    GW_SetCurrentWeekday((uint8_t)weekday);
+    if (HAL_RTC_SetTime(&hrtc, &GW_currentTime, RTC_FORMAT_BIN) != HAL_OK ||
+        HAL_RTC_SetDate(&hrtc, &GW_currentDate, RTC_FORMAT_BIN) != HAL_OK)
+    {
+        Error_Handler();
+    }
 }

--- a/Core/Src/sdcard.c
+++ b/Core/Src/sdcard.c
@@ -30,8 +30,10 @@ void sdcard_init_spi1() {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    // Reset sd card by setting VCC to 0 for 5ms
-    timer_on(0, 5); 
+    // Reset sd card by setting VCC to 0 for 50ms (5ms was borderline for
+    // discharging the SD slot's bulk caps when a prior crashed application
+    // left the card mid-write).
+    timer_on(0, 50);
     while (timer_status(0));
     /* PA15 = 0v : Enable SD Card VCC */
     HAL_GPIO_WritePin(SD_VCC_GPIO_Port, SD_VCC_Pin, GPIO_PIN_SET);

--- a/gnwmanager/cli/_dump.py
+++ b/gnwmanager/cli/_dump.py
@@ -59,7 +59,7 @@ def dump(
                 raise ValueError("Must specify size if reading from RAM address.")
 
         chunk_size = 256 << 10
-        for _ in tqdm(range(0, size, chunk_size)):
+        for _ in tqdm(range(0, size, chunk_size), desc=dst.name):
             chunk_size = min(chunk_size, size)
             chunks.append(gnw.read_memory(addr, chunk_size))
             addr += chunk_size

--- a/gnwmanager/cli/_flash.py
+++ b/gnwmanager/cli/_flash.py
@@ -56,4 +56,4 @@ def flash(
         raise ValueError("Unsupported destination address.")
 
     log.info(f"Flashing {len(data)} bytes to {'bank ' + str(bank) if bank else 'ext'} with relative-offset {offset}.")
-    gnw.flash(bank, offset, data, progress=progress)
+    gnw.flash(bank, offset, data, progress=progress, desc=file.name)

--- a/gnwmanager/cli/_patch.py
+++ b/gnwmanager/cli/_patch.py
@@ -150,7 +150,7 @@ def mario(
     gnw.start_gnwmanager()
     gnw.flash(1, 0, bytes(device.internal), progress=False)
     if device.external:
-        gnw.flash(0, 0, bytes(device.external), progress=True)
+        gnw.flash(0, 0, bytes(device.external), progress=True, desc="patched firmware")
     if bootloader:
         flash_bootloader(0x08032000, gnw=gnw, repo=bootloader_repo, tag=bootloader_tag, label="0x08032000")
 
@@ -216,6 +216,6 @@ def zelda(
     gnw.start_gnwmanager()
     gnw.flash(1, 0, bytes(device.internal), progress=False)
     if device.external:
-        gnw.flash(0, 0, bytes(device.external), progress=True)
+        gnw.flash(0, 0, bytes(device.external), progress=True, desc="patched firmware")
     if bootloader:
         flash_bootloader(0x08032000, gnw=gnw, repo=bootloader_repo, tag=bootloader_tag, label="0x08032000")

--- a/gnwmanager/cli/devices.py
+++ b/gnwmanager/cli/devices.py
@@ -117,7 +117,7 @@ class DeviceModel(Registry, suffix="Model"):
 
     @classmethod
     def autodetect(cls, gnw: GnW):
-        for device_constructor in DeviceModel.values():
+        for device_constructor in DeviceModel.values():  # pyright: ignore[reportAttributeAccessIssue]
             device = device_constructor(gnw)
             with suppress(HashMismatchError):
                 device.read_itcm()

--- a/gnwmanager/cli/main.py
+++ b/gnwmanager/cli/main.py
@@ -248,25 +248,36 @@ def main(
     except DebugProbeConnectionError as e:
         rich.print(f"[red]Error communicating with device ({e}). Is it ON and connected?[/red]")
         close_on_exit = False
+        if exit_on_error:
+            sys.exit(1)
     except DataError as e:
+        first_arg = e.args[0] if e.args and isinstance(e.args[0], str) else ""
         if e.args == ("BAD_FLASH_COMM",):
-            rich.print("Failed to communicate with external flash chip. Check your soldering!")
+            rich.print("[red]Failed to communicate with external flash chip. Check your soldering![/red]")
         elif e.args == ("BAD_SD_FS_MOUNT",):
-            rich.print("Failed to mount filesystem on SD Card!")
+            rich.print("[red]Failed to mount filesystem on SD Card![/red]")
         elif e.args == ("BAD_SD_OPEN",):
-            rich.print("Failed to open file on SD Card!")
+            rich.print("[red]Failed to open file on SD Card![/red]")
         elif e.args == ("BAD_SD_WRITE",):
-            rich.print("Failed to write file on SD Card!")
+            rich.print("[red]Failed to write file on SD Card![/red]")
         elif e.args == ("BAD_SD_UNLINK",):
-            rich.print("Failed to delete file on SD Card!")
+            rich.print("[red]Failed to delete file on SD Card![/red]")
         elif e.args == ("BAD_SD_DIR",):
-            rich.print("Failed to open directory on SD Card!")
+            rich.print("[red]Failed to open directory on SD Card![/red]")
         elif e.args == ("BAD_SD_LIST_TRUNC",):
-            rich.print("SD directory listing was truncated (too many entries or long names).")
+            rich.print("[red]SD directory listing was truncated (too many entries or long names).[/red]")
         elif e.args == ("BAD_SD_READ",):
-            rich.print("Failed to read file from SD Card!")
+            rich.print("[red]Failed to read file from SD Card![/red]")
+        elif first_arg.startswith(("BAD_HASH_RAM_COMPRESSED", "BAD_HASH_RAM", "BAD_HASH_FLASH")):
+            status = first_arg.split(":", 1)[0]
+            rich.print(
+                f"[red]Transfer corruption ({status}) persisted after retries. "
+                "Try lowering `--frequency` or check your wiring/soldering.[/red]"
+            )
         else:
-            rich.print(f"Unexpected response from debug probe. {e}")
+            rich.print(f"[red]Unexpected response from debug probe. {e}[/red]")
+        if exit_on_error:
+            sys.exit(1)
     except ConnectionResetError:
         print(traceback.format_exc())
         close_on_exit = False

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from copy import deepcopy
 from itertools import count
 from math import ceil
+from pathlib import PurePosixPath
 from time import sleep, time
 from typing import Dict, List, Literal, NamedTuple, Optional, Union
 
@@ -402,6 +403,7 @@ class GnW:
         offset: int,
         data: bytes,
         progress: bool = False,
+        desc: Optional[str] = None,
     ):
         """High level convenience function for flashing any-length data to any flash location."""
         if bank == 0:
@@ -409,7 +411,7 @@ class GnW:
             if len(data) > self.external_flash_size:
                 raise ValueError("Data cannot fit into external flash.")
 
-            self._flash_ext(offset, data, progress=progress)
+            self._flash_ext(offset, data, progress=progress, desc=desc)
         elif bank in (1, 2):
             data = pad_bytes(data, 8192)
             if len(data) > (256 << 10):
@@ -495,6 +497,7 @@ class GnW:
         offset: int,
         data: bytes,
         progress: bool = False,
+        desc: Optional[str] = None,
     ):
         validate_extflash_offset(offset)
 
@@ -513,7 +516,7 @@ class GnW:
         ]
 
         log.info(f"{len(packets)} packets need to be programmed.")
-        for i, packet in enumerate(tqdm(packets) if progress else packets):
+        for i, packet in enumerate(tqdm(packets, desc=desc) if progress else packets):
             log.info(f"Programming packet {i + 1}/{len(packets)}.")
             self.program(0, packet.addr, packet.data, blocking=False)
             self.write_uint32("progress", int(26 * (i + 1) / len(packets)))
@@ -610,7 +613,7 @@ class GnW:
             log.info("Programming empty file.")
             self._sd_write_file_chunk(path, 0, 1, blocking=False)
 
-        for i, packet in enumerate(tqdm(chunks) if progress else chunks):
+        for i, packet in enumerate(tqdm(chunks, desc=PurePosixPath(path).name) if progress else chunks):
             log.info(f"Programming packet {i + 1}/{len(chunks)}.")
             self._sd_write_file_chunk(path, i, len(chunks), packet, blocking=False)
             self.write_uint32("progress", int(26 * (i + 1) / len(chunks)))
@@ -699,7 +702,7 @@ class GnW:
 
         log.info(f"Data fetched in {len(ranges)} packets.")
         out = bytearray()
-        for i, (off, nb) in enumerate(tqdm(ranges, disable=not progress)):
+        for i, (off, nb) in enumerate(tqdm(ranges, desc=PurePosixPath(path).name, disable=not progress)):
             log.info(f"Reading packet {i + 1}/{len(ranges)}.")
             chunk = self._sd_read_file_chunk(path, off, nb, blocking=False)
             out.extend(chunk)

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -27,6 +27,29 @@ class Variable(NamedTuple):
 
 ERROR_MASK = 0xFFFF_0000
 
+# Status strings that indicate the bytes the host wrote to device RAM didn't
+# survive the debug-probe transfer intact. The data on device flash/SD is fine;
+# the corruption is in the in-flight buffer.
+#
+# BAD_HASH_RAM_COMPRESSED is handled in-protocol via chunk-level retry (the
+# device parks in HASH_RETRY_WAIT and the host re-transmits to the same context
+# buffer). BAD_HASH_RAM (decompressed-data check failure) falls through to the
+# operation-level retry wrapper, which reloads firmware and starts over.
+_TRANSFER_CORRUPTION_PREFIXES = ("BAD_HASH_RAM_COMPRESSED", "BAD_HASH_RAM")
+
+# Operation-level: full reload + restart on persistent transfer corruption.
+_MAX_TRANSFER_RETRIES = 2
+
+# Chunk-level: re-transmit a single context buffer without reloading firmware.
+_MAX_CHUNK_RETRIES = 3
+
+
+def _is_transfer_corruption_error(exc: "DataError") -> bool:
+    if not exc.args or not isinstance(exc.args[0], str):
+        return False
+    return exc.args[0].startswith(_TRANSFER_CORRUPTION_PREFIXES)
+
+
 actions: dict[str, int] = {
     "ERASE_AND_FLASH": 0,
     "HASH": 1,
@@ -55,7 +78,15 @@ def _populate_comm():
     _comm["download_in_progress"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
     _comm["expected_hash"] = last_variable = Variable(last_variable.address + last_variable.size, 32)
     _comm["actual_hash"] = last_variable = Variable(last_variable.address + last_variable.size, 32)
-    _comm["dest_path"] = last_variable = Variable(last_variable.address + last_variable.size, 256)
+
+    # Per-chunk retry handshake. When the device detects BAD_HASH_RAM_COMPRESSED
+    # it parks in HASH_RETRY_WAIT, publishes the index of the corrupted context
+    # buffer, and waits for the host to re-transmit the data and bump
+    # retry_request. The device echoes retry_request into retry_ack once it
+    # has re-loaded working_context from the (rewritten) source context.
+    _comm["failed_context_idx"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
+    _comm["retry_request"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
+    _comm["retry_ack"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
 
     for i in range(2):
         struct_start = _comm["flashapp_comm"].address + ((i + 1) * 1024)
@@ -119,6 +150,12 @@ class GnW:
         self._external_flash_block_size = 0
         self._gnwmanager_started = False
         self.default_filesystem_offset = 0
+        # Per-context retry state for the BAD_HASH_RAM_COMPRESSED chunk-retry
+        # handshake. Each slot holds either None (nothing recoverable in flight)
+        # or a dict with the buffer bytes + hashes the host wrote, plus an
+        # `attempts` counter. Populated by program()/sd_write_file_chunk()
+        # whenever they push compressed data to a context.
+        self._in_flight_retry: list[Optional[dict]] = [None, None]
 
     @property
     def external_flash_size(self) -> int:
@@ -176,6 +213,85 @@ class GnW:
         # earlier bursts (large buffers, long paths) have landed (manifests as
         # BAD_HASH_RAM_COMPRESSED for sdpush/flash). Cheap: one extra word read.
         self.read_uint32(context["buffer"].address)
+
+    def _record_in_flight_compressed(self, context, *, buffer_data: bytes,
+                                     compressed_sha256: bytes, expected_sha256: bytes):
+        """Stash what was written to this context so the chunk-retry handshake can resend it.
+
+        Driven from `_get_status` on BAD_HASH_RAM_COMPRESSED.
+        """
+        idx = _contexts.index(context)
+        self._in_flight_retry[idx] = {
+            "buffer_data": buffer_data,
+            "compressed_sha256": compressed_sha256,
+            "expected_sha256": expected_sha256,
+            "attempts": 0,
+        }
+
+    def _try_chunk_retry(self) -> bool:
+        """Re-transmit a corrupted context buffer via the HASH_RETRY_WAIT handshake.
+
+        Returns True if a retry was issued (caller should re-poll status),
+        False if no retry is possible (caller surfaces the error). Exhausted
+        attempts and a missing in-flight record (e.g. an uncompressed transfer
+        — but those don't trip BAD_HASH_RAM_COMPRESSED) both fall back to
+        operation-level retry.
+        """
+        failed_idx = self.read_uint32("failed_context_idx")
+        if failed_idx not in (0, 1):
+            return False
+        saved = self._in_flight_retry[failed_idx]
+        if saved is None or saved["attempts"] >= _MAX_CHUNK_RETRIES:
+            return False
+
+        context = _contexts[failed_idx]
+        saved["attempts"] += 1
+        log.warning(
+            f"BAD_HASH_RAM_COMPRESSED on context {failed_idx}; "
+            f"re-transmitting buffer (attempt {saved['attempts']}/{_MAX_CHUNK_RETRIES})."
+        )
+
+        self.write_uint32("upload_in_progress", 1)
+        self.write_memory(context["buffer"], saved["buffer_data"])
+        self.write_memory(context["compressed_sha256"], saved["compressed_sha256"])
+        self.write_memory(context["expected_sha256"], saved["expected_sha256"])
+        self._drain_pending_writes(context)
+
+        new_request = self.read_uint32("retry_request") + 1
+        self.write_uint32("retry_request", new_request)
+        self.write_uint32("upload_in_progress", 0)
+
+        # Wait for the device to consume retry_request — at that point it has
+        # already re-loaded working_context and transitioned back to DECOMPRESSING.
+        deadline = time() + 10
+        while self.read_uint32("retry_ack") != new_request:
+            if time() > deadline:
+                log.warning(f"Retry ack timeout on context {failed_idx}.")
+                return False
+            sleep(0.01)
+        return True
+
+    def _with_transfer_retry(self, op_name: str, fn, *args, **kwargs):
+        """Run ``fn`` and retry on transfer-corruption errors (BAD_HASH_RAM*).
+
+        The failure surfaces in a later status poll rather than at the call
+        that queued the bad chunk, so we can't isolate the failing chunk —
+        retry reloads firmware (resetting the context state machine) and
+        re-runs the whole operation. Re-flashing is idempotent: the firmware
+        short-circuits chunks whose hash already matches.
+        """
+        for attempt in range(_MAX_TRANSFER_RETRIES + 1):
+            try:
+                return fn(*args, **kwargs)
+            except DataError as e:
+                if attempt == _MAX_TRANSFER_RETRIES or not _is_transfer_corruption_error(e):
+                    raise
+                first_line = e.args[0].splitlines()[0]
+                log.warning(
+                    f"{op_name}: {first_line} on attempt {attempt + 1}/{_MAX_TRANSFER_RETRIES + 1}; "
+                    "reloading firmware and retrying."
+                )
+                self.start_gnwmanager(force=True)
 
     def wait_for_idle(self, timeout: float = 120):
         """Block until the on-device status is IDLE.
@@ -309,6 +425,9 @@ class GnW:
 
     def reset_context_counter(self):
         self.context_counter = 1
+        # Any prior in-flight buffers are gone with the device's RAM; the
+        # next program/sd_write_file_chunk will repopulate as needed.
+        self._in_flight_retry = [None, None]
         log.debug(f"context_counter reset to {self.context_counter}.")
 
     def reset(self):
@@ -324,16 +443,21 @@ class GnW:
         self._gnwmanager_started = False
 
     def _get_status(self, raise_on_error=True) -> str:
-        status_enum = self.read_uint32("status")
-        status_str = flashapp_status_enum_to_str.get(status_enum, "UNKNOWN")
-        if raise_on_error and (status_enum & ERROR_MASK) == 0xBAD0_0000:
-            if status_str in ("BAD_HASH_RAM", "BAD_HASH_RAM_COMPRESSED", "BAD_HASH_FLASH"):
-                expected_hash = self.read_memory("expected_hash")
-                actual_hash = self.read_memory("actual_hash")
-                raise DataError(f"{status_str}:\nExpected: {expected_hash.hex()}\nActual: {actual_hash.hex()}")
-            else:
+        while True:
+            status_enum = self.read_uint32("status")
+            status_str = flashapp_status_enum_to_str.get(status_enum, "UNKNOWN")
+            if raise_on_error and (status_enum & ERROR_MASK) == 0xBAD0_0000:
+                # In-protocol chunk retry: device parks in HASH_RETRY_WAIT and
+                # we resend the corrupted buffer without reloading firmware.
+                # Falls through to the DataError raise once retries are spent.
+                if status_str == "BAD_HASH_RAM_COMPRESSED" and self._try_chunk_retry():
+                    continue
+                if status_str in ("BAD_HASH_RAM", "BAD_HASH_RAM_COMPRESSED", "BAD_HASH_FLASH"):
+                    expected_hash = self.read_memory("expected_hash")
+                    actual_hash = self.read_memory("actual_hash")
+                    raise DataError(f"{status_str}:\nExpected: {expected_hash.hex()}\nActual: {actual_hash.hex()}")
                 raise DataError(status_str)
-        return status_str
+            return status_str
 
     def get_context(self, timeout=120):
         """Return the next available context slot (first with `ready == 0`).
@@ -365,6 +489,10 @@ class GnW:
             for i, context in enumerate(_contexts):
                 ready = self.read_uint32(context["ready"])
                 if not ready:
+                    # Slot is free → its prior work succeeded; drop stale
+                    # retry tracking so a future BAD_HASH_RAM_COMPRESSED on
+                    # this slot can't pull data from a finished chunk.
+                    self._in_flight_retry[i] = None
                     log.debug(f"Got context {i} in {time() - t_start:.3f}s.")
                     return context
                 ready_states.append(ready)
@@ -506,9 +634,16 @@ class GnW:
         self.write_memory(context["expected_sha256"], data_hash)
 
         if compress:
+            compressed_hash = sha256(compressed_data)
             self.write_uint32(context["compressed_size"], len(compressed_data))
             self.write_memory(context["buffer"], compressed_data)
-            self.write_memory(context["compressed_sha256"], sha256(compressed_data))
+            self.write_memory(context["compressed_sha256"], compressed_hash)
+            self._record_in_flight_compressed(
+                context,
+                buffer_data=compressed_data,
+                compressed_sha256=compressed_hash,
+                expected_sha256=data_hash,
+            )
         else:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)
@@ -535,18 +670,19 @@ class GnW:
         desc: Optional[str] = None,
     ):
         """High level convenience function for flashing any-length data to any flash location."""
+        op_name = f"flash bank={bank} offset=0x{offset:x}"
         if bank == 0:
             data = pad_bytes(data, self.external_flash_block_size)
             if len(data) > self.external_flash_size:
                 raise ValueError("Data cannot fit into external flash.")
 
-            self._flash_ext(offset, data, progress=progress, desc=desc)
+            self._with_transfer_retry(op_name, self._flash_ext, offset, data, progress=progress, desc=desc)
         elif bank in (1, 2):
             data = pad_bytes(data, 8192)
             if len(data) > (256 << 10):
                 raise ValueError("Data cannot fit into internal flash.")
 
-            self.program(bank, offset, data)
+            self._with_transfer_retry(op_name, self.program, bank, offset, data)
         else:
             raise ValueError
 
@@ -705,9 +841,16 @@ class GnW:
         self.write_memory(context["expected_sha256"], data_hash)
 
         if compress:
+            compressed_hash = sha256(compressed_data)
             self.write_uint32(context["compressed_size"], len(compressed_data))
             self.write_memory(context["buffer"], compressed_data)
-            self.write_memory(context["compressed_sha256"], sha256(compressed_data))
+            self.write_memory(context["compressed_sha256"], compressed_hash)
+            self._record_in_flight_compressed(
+                context,
+                buffer_data=compressed_data,
+                compressed_sha256=compressed_hash,
+                expected_sha256=data_hash,
+            )
         else:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)
@@ -735,6 +878,9 @@ class GnW:
             raise ValueError(f"path shall not be a folder {path}")
         if not path.startswith("/"):
             raise ValueError(f"path shall start with '/' {path}")
+        self._with_transfer_retry(f"sdpush {path}", self._sd_write_file_impl, path, data, progress)
+
+    def _sd_write_file_impl(self, path: str, data: bytes, progress: bool):
         chunk_size = self.contexts[0]["buffer"].size  # Assumes all contexts have same size buffer
         chunks = chunk_bytes(data, chunk_size)
 

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -73,6 +73,7 @@ def _populate_comm():
         _contexts[i]["dest_path"] = last_variable = Variable(last_variable.address + last_variable.size, 256)
         _contexts[i]["block"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
         _contexts[i]["total_blocks"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
+        _contexts[i]["compressed_sha256"] = last_variable = Variable(last_variable.address + last_variable.size, 32)
 
         _contexts[i]["ready"] = last_variable = Variable(last_variable.address + last_variable.size, 4)
 
@@ -379,6 +380,7 @@ class GnW:
         if compress:
             self.write_uint32(context["compressed_size"], len(compressed_data))
             self.write_memory(context["buffer"], compressed_data)
+            self.write_memory(context["compressed_sha256"], sha256(compressed_data))
         else:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)
@@ -573,6 +575,7 @@ class GnW:
         if compress:
             self.write_uint32(context["compressed_size"], len(compressed_data))
             self.write_memory(context["buffer"], compressed_data)
+            self.write_memory(context["compressed_sha256"], sha256(compressed_data))
         else:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -170,6 +170,13 @@ class GnW:
         byte_val = val.encode("utf-8") + b"\x00"
         self.write_memory(key, byte_val)
 
+    def _drain_pending_writes(self, context):
+        # ADIv5 posted-write drain: any AP read flushes pending writes through the
+        # debug adapter. Without this, the running CPU can see `ready` flip before
+        # earlier bursts (large buffers, long paths) have landed (manifests as
+        # BAD_HASH_RAM_COMPRESSED for sdpush/flash). Cheap: one extra word read.
+        self.read_uint32(context["buffer"].address)
+
     def wait_for_idle(self, timeout: float = 120):
         """Block until the on-device status is IDLE.
 
@@ -320,7 +327,7 @@ class GnW:
         status_enum = self.read_uint32("status")
         status_str = flashapp_status_enum_to_str.get(status_enum, "UNKNOWN")
         if raise_on_error and (status_enum & ERROR_MASK) == 0xBAD0_0000:
-            if status_str in ("BAD_HASH_RAM", "BAD_HASH_FLASH"):
+            if status_str in ("BAD_HASH_RAM", "BAD_HASH_RAM_COMPRESSED", "BAD_HASH_FLASH"):
                 expected_hash = self.read_memory("expected_hash")
                 actual_hash = self.read_memory("actual_hash")
                 raise DataError(f"{status_str}:\nExpected: {expected_hash.hex()}\nActual: {actual_hash.hex()}")
@@ -505,6 +512,8 @@ class GnW:
         else:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)
+
+        self._drain_pending_writes(context)
 
         log.debug(f"Activating PROGRAM: {data_hash.hex()}")
         self.write_uint32(context["ready"], self.context_counter)
@@ -703,6 +712,8 @@ class GnW:
             self.write_uint32(context["compressed_size"], 0)
             self.write_memory(context["buffer"], data)
 
+        self._drain_pending_writes(context)
+
         log.debug(f"Activating PROGRAM: {data_hash.hex()}")
         self.write_uint32(context["ready"], self.context_counter)
         self.context_counter += 1
@@ -764,6 +775,7 @@ class GnW:
         self.write_str(context["dest_path"], path)
         self.write_uint32(context["offset"], offset)
         self.write_uint32(context["size"], max_bytes)
+        self._drain_pending_writes(context)
         self.write_uint32(context["ready"], self.context_counter)
         self.context_counter += 1
         log.debug(f"context_counter incremented to {self.context_counter}.")
@@ -790,6 +802,7 @@ class GnW:
         self.write_str(context["dest_path"], path)
         self.write_uint32(context["offset"], 0)
         self.write_uint32(context["size"], 0)
+        self._drain_pending_writes(context)
         self.write_uint32(context["ready"], self.context_counter)
         self.context_counter += 1
         log.debug(f"context_counter incremented to {self.context_counter}.")
@@ -842,6 +855,7 @@ class GnW:
         self.write_uint32(context["response_ready"], 0)
         self.write_uint32(context["action"], actions["DELETE_FILE_FROM_SD"])
         self.write_str(context["dest_path"], path)
+        self._drain_pending_writes(context)
         self.write_uint32(context["ready"], self.context_counter)
         self.context_counter += 1
         log.debug(f"context_counter incremented to {self.context_counter}.")
@@ -860,6 +874,7 @@ class GnW:
         self.write_uint32(context["response_ready"], 0)
         self.write_uint32(context["action"], actions["LIST_SD_DIR"])
         self.write_str(context["dest_path"], path)
+        self._drain_pending_writes(context)
         self.write_uint32(context["ready"], self.context_counter)
         self.context_counter += 1
         log.debug(f"context_counter incremented to {self.context_counter}.")

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -214,8 +214,9 @@ class GnW:
         # BAD_HASH_RAM_COMPRESSED for sdpush/flash). Cheap: one extra word read.
         self.read_uint32(context["buffer"].address)
 
-    def _record_in_flight_compressed(self, context, *, buffer_data: bytes,
-                                     compressed_sha256: bytes, expected_sha256: bytes):
+    def _record_in_flight_compressed(
+        self, context, *, buffer_data: bytes, compressed_sha256: bytes, expected_sha256: bytes
+    ):
         """Stash what was written to this context so the chunk-retry handshake can resend it.
 
         Driven from `_get_status` on BAD_HASH_RAM_COMPRESSED.
@@ -327,9 +328,7 @@ class GnW:
             if i % 10 == 0:
                 log.debug(f"waiting for device to IDLE; current status: {status_str}")
             if time() - t_progress > timeout:
-                raise TimeoutError(
-                    f"wait_for_idle: no status progress for {timeout:.1f}s (status={status_str})"
-                )
+                raise TimeoutError(f"wait_for_idle: no status progress for {timeout:.1f}s (status={status_str})")
             sleep(0.1)
         log.debug(f"Waited {time() - t_start:.3f}s for device idle.")
 

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -170,46 +170,133 @@ class GnW:
         byte_val = val.encode("utf-8") + b"\x00"
         self.write_memory(key, byte_val)
 
-    def wait_for_idle(self, timeout: float = 20):
-        """Block until the on-device status is IDLE."""
+    def wait_for_idle(self, timeout: float = 120):
+        """Block until the on-device status is IDLE.
+
+        `timeout` is a *no-progress* budget, not a total wall-clock budget:
+        the deadline resets every time the device's status string changes.
+        A slow operation that keeps making forward progress is tolerated
+        indefinitely; only a stall with no status change for `timeout`
+        seconds raises.
+
+        Parameters
+        ----------
+        timeout: float
+            Maximum seconds to wait without observing any status change.
+
+        Raises
+        ------
+        TimeoutError
+            If the on-device status does not change for `timeout` seconds.
+        """
         log.debug("Waiting for device to idle.")
         t_start = time()
-        t_deadline = t_start + timeout
+        t_progress = t_start
+        last_status = None
 
         for i in count():
             status_str = self._get_status()
             if status_str == "IDLE":
                 break
+            if status_str != last_status:
+                t_progress = time()
+                last_status = status_str
             if i % 10 == 0:
                 log.debug(f"waiting for device to IDLE; current status: {status_str}")
-            if time() > t_deadline:
-                raise TimeoutError("wait_for_idle")
+            if time() - t_progress > timeout:
+                raise TimeoutError(
+                    f"wait_for_idle: no status progress for {timeout:.1f}s (status={status_str})"
+                )
             sleep(0.1)
         log.debug(f"Waited {time() - t_start:.3f}s for device idle.")
 
-    def wait_for_all_contexts_complete(self, timeout=20):
+    def wait_for_all_contexts_complete(self, timeout=120):
+        """Wait for every in-flight context slot to be acked by the device.
+
+        `timeout` is a *no-progress* budget per context, not a total
+        wall-clock budget: while waiting on a given context the deadline
+        resets every time its `ready` field or the device `status` changes.
+        Slow but advancing operations (e.g. a long FAT sync on a slow SD
+        card) are tolerated indefinitely; only a stall with no observable
+        state change for `timeout` seconds raises.
+
+        Parameters
+        ----------
+        timeout: float
+            Maximum seconds to wait without observing any change in the
+            current context's `ready` field or the device status. The same
+            budget is also passed to the trailing `wait_for_idle` call.
+
+        Raises
+        ------
+        TimeoutError
+            If no progress is observed on a context for `timeout` seconds.
+        """
         log.debug("Waiting for all contexts to complete.")
         t_start = time()
-        t_deadline = t_start + timeout
         for i, context in enumerate(_contexts):
-            while self.read_uint32(context["ready"]):
-                self._get_status()
-                if time() > t_deadline:
-                    raise TimeoutError("wait_for_all_contexts_complete")
+            t_progress = time()
+            last_ready = None
+            last_status = None
+            while True:
+                cur_ready = self.read_uint32(context["ready"])
+                if not cur_ready:
+                    break
+                cur_status = self._get_status()
+                if cur_ready != last_ready or cur_status != last_status:
+                    t_progress = time()
+                    last_ready = cur_ready
+                    last_status = cur_status
+                if time() - t_progress > timeout:
+                    raise TimeoutError(
+                        f"wait_for_all_contexts_complete: no progress for {timeout:.1f}s "
+                        f"on context {i} (ready=0x{cur_ready:x}, status={cur_status})"
+                    )
                 sleep(0.1)
             log.debug(f"Context {i} complete.")
         log.debug(f"Waited {time() - t_start:.3f}s for all contexts to complete.")
         self._get_status()
-        self.wait_for_idle(timeout=t_deadline - time())
+        self.wait_for_idle(timeout=timeout)
 
-    def wait_for_context_response(self, context, timeout=20):
+    def wait_for_context_response(self, context, timeout=120):
+        """Wait for the device to write a response into `context`.
+
+        `timeout` is a *no-progress* budget, not a total wall-clock budget:
+        the deadline resets every time the device status string changes
+        (the status is polled each iteration, which also surfaces device
+        errors via `_get_status`). A slow but advancing query is tolerated
+        indefinitely; only a stall with no status change for `timeout`
+        seconds raises.
+
+        Parameters
+        ----------
+        context: dict
+            The context slot previously handed work; its `response_ready`
+            flag is polled.
+        timeout: float
+            Maximum seconds to wait without observing any status change.
+
+        Raises
+        ------
+        TimeoutError
+            If the device status does not change for `timeout` seconds
+            before `response_ready` becomes non-zero.
+        """
         context_index = _contexts.index(context)
         log.debug(f"Waiting on context {context_index} for response.")
         t_start = time()
-        t_deadline = t_start + timeout
+        t_progress = t_start
+        last_status = None
         while not self.read_uint32(context["response_ready"]):
-            if time() > t_deadline:
-                raise TimeoutError("wait_for_context_response")
+            cur_status = self._get_status()
+            if cur_status != last_status:
+                t_progress = time()
+                last_status = cur_status
+            if time() - t_progress > timeout:
+                raise TimeoutError(
+                    f"wait_for_context_response: no progress for {timeout:.1f}s "
+                    f"on context {context_index} (status={cur_status})"
+                )
             sleep(0.1)
         log.debug(f"Waited {time() - t_start:.3f}s for context {context_index} response.")
 
@@ -241,18 +328,51 @@ class GnW:
                 raise DataError(status_str)
         return status_str
 
-    def get_context(self, timeout=20):
+    def get_context(self, timeout=120):
+        """Return the next available context slot (first with `ready == 0`).
+
+        `timeout` is a *no-progress* budget, not a total wall-clock budget:
+        the deadline resets every time any slot's `ready` value or the
+        device status changes. While the device keeps draining queued work
+        the wait can extend indefinitely; only a stall with no observable
+        state change for `timeout` seconds raises.
+
+        Parameters
+        ----------
+        timeout: float
+            Maximum seconds to wait without observing any change in either
+            slot's `ready` field or the device status.
+
+        Raises
+        ------
+        TimeoutError
+            If no slot becomes available and no progress is observed for
+            `timeout` seconds.
+        """
         t_start = time()
-        t_deadline = t_start + timeout
+        t_progress = t_start
+        last_ready = None
+        last_status = None
         while True:
+            ready_states = []
             for i, context in enumerate(_contexts):
-                if not self.read_uint32(context["ready"]):
+                ready = self.read_uint32(context["ready"])
+                if not ready:
                     log.debug(f"Got context {i} in {time() - t_start:.3f}s.")
                     return context
-                self._get_status()
-                if time() > t_deadline:
-                    log.debug(f"Timeout ({timeout}s) reached waiting to get an available context.")
-                    raise TimeoutError
+                ready_states.append(ready)
+            cur_ready = tuple(ready_states)
+            cur_status = self._get_status()
+            if cur_ready != last_ready or cur_status != last_status:
+                t_progress = time()
+                last_ready = cur_ready
+                last_status = cur_status
+            if time() - t_progress > timeout:
+                log.debug(f"Timeout ({timeout}s no-progress) waiting for an available context.")
+                raise TimeoutError(
+                    f"get_context: no progress for {timeout:.1f}s "
+                    f"(ready={[f'0x{r:x}' for r in ready_states]}, status={cur_status})"
+                )
             sleep(0.1)
 
     def filesystem(self, offset: Optional[int] = None, **kwargs):

--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -83,10 +83,10 @@ def _openocd_launch_commands(port: int) -> Generator[tuple[str, list[str]], None
     yield "jlink", cmd
 
     # CMSIS-DAP (pi pico). Bit-banged SWD via RP2040 PIO with no level shifting;
-    # signal integrity on hand-soldered G&W flying leads degrades quickly above
-    # ~2 MHz and surfaces as BAD_HASH_RAM_COMPRESSED. 2 MHz is the safe default.
+    # signal integrity on hand-soldered G&W flying leads degrades quickly past
+    # ~1 MHz and surfaces as BAD_HASH_RAM_COMPRESSED. 1 MHz is the safe default.
     cmd = base_cmd.copy()
-    cmd.extend(["-c", "adapter speed 2000"])
+    cmd.extend(["-c", "adapter speed 1000"])
     cmd.extend(["-c", "source [find interface/cmsis-dap.cfg]"])
     cmd.extend(["-c", "transport select swd"])
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])

--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -82,9 +82,11 @@ def _openocd_launch_commands(port: int) -> Generator[tuple[str, list[str]], None
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])
     yield "jlink", cmd
 
-    # CMSIS-DAP (pi pico)
+    # CMSIS-DAP (pi pico). Bit-banged SWD via RP2040 PIO with no level shifting;
+    # signal integrity on hand-soldered G&W flying leads degrades quickly above
+    # ~2 MHz and surfaces as BAD_HASH_RAM_COMPRESSED. 2 MHz is the safe default.
     cmd = base_cmd.copy()
-    cmd.extend(["-c", "adapter speed 4000"])
+    cmd.extend(["-c", "adapter speed 2000"])
     cmd.extend(["-c", "source [find interface/cmsis-dap.cfg]"])
     cmd.extend(["-c", "transport select swd"])
     cmd.extend(["-c", "source [find target/stm32h7x.cfg]"])

--- a/gnwmanager/ocdbackend/openocd_backend.py
+++ b/gnwmanager/ocdbackend/openocd_backend.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import re
@@ -5,11 +6,12 @@ import shutil
 import socket
 import subprocess
 import tempfile
+from collections import deque
 from collections.abc import Generator
 from pathlib import Path
 from threading import Thread
 from time import sleep, time
-from typing import List, Tuple
+from typing import Deque, List, Tuple
 
 from gnwmanager.exceptions import DataError, DebugProbeConnectionError, MissingThirdPartyError
 from gnwmanager.ocdbackend.base import OCDBackend, TransferErrors
@@ -35,11 +37,20 @@ TransferErrors.add(OpenOCDError)
 _ramdisk = Path("/dev/shm")
 
 
-def process_output(stream):
-    for line in iter(stream.readline, ""):
-        text = line.decode().rstrip()
+def _drain_stderr(stream, buffer: "Deque[str]", level: int) -> None:
+    """Continuously drain a subprocess stderr pipe.
+
+    OpenOCD's stderr is a fixed-size OS pipe (~64 KB). If nothing reads it, the
+    buffer eventually fills, OpenOCD's next write to stderr blocks, and it stops
+    servicing the TCL command socket — wedging all transfers mid-session. This
+    thread keeps the pipe drained at all times, retaining recent lines in
+    ``buffer`` for later error reporting.
+    """
+    for line in iter(stream.readline, b""):
+        text = line.decode(errors="replace").rstrip()
         if text:
-            log.debug(text)
+            buffer.append(text)
+            log.log(level, text)
 
 
 def _pi_find_gpio_number(gpio_name):
@@ -196,6 +207,8 @@ class OpenOCDBackend(OCDBackend):
         super().__init__()
         self._address = ("localhost", port)
         self._openocd_process = None
+        self._stderr_buffer: Deque[str] = deque(maxlen=1000)
+        self._stderr_thread = None
         self.version = _get_openocd_version()
 
     def open(self) -> OCDBackend:
@@ -204,10 +217,16 @@ class OpenOCDBackend(OCDBackend):
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._openocd_process = _launch_openocd(self._address[1])
 
-        if env_is_yes_like("GNWMANAGER_OPENOCD_DEBUG"):
-            debug_thread = Thread(target=process_output, args=(self._openocd_process.stderr,))
-            debug_thread.daemon = True
-            debug_thread.start()
+        # Always drain stderr, otherwise the OS pipe buffer fills and OpenOCD
+        # deadlocks mid-session. GNWMANAGER_OPENOCD_DEBUG only controls whether
+        # the drained lines are surfaced (INFO) or kept quiet (DEBUG).
+        level = logging.INFO if env_is_yes_like("GNWMANAGER_OPENOCD_DEBUG") else logging.DEBUG
+        self._stderr_thread = Thread(
+            target=_drain_stderr,
+            args=(self._openocd_process.stderr, self._stderr_buffer, level),
+            daemon=True,
+        )
+        self._stderr_thread.start()
 
         for _ in range(5):
             try:
@@ -226,7 +245,24 @@ class OpenOCDBackend(OCDBackend):
             if self._openocd_process and self._openocd_process.poll() is None:
                 self._openocd_process.terminate()
                 self._openocd_process.wait()
+            if self._stderr_thread is not None:
+                self._stderr_thread.join(timeout=2)
+                self._stderr_thread = None
             self._openocd_process = None
+
+    def _collect_stderr(self) -> str:
+        """Wait for OpenOCD to exit and return its drained stderr output.
+
+        Reads from the buffer filled by the background drain thread instead of
+        calling ``process.communicate()`` (which would race with that thread for
+        the pipe).
+        """
+        if self._openocd_process is not None:
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                self._openocd_process.wait(timeout=2)
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=2)
+        return "\n".join(self._stderr_buffer)
 
     def __call__(self, cmd: str, *, decode=True) -> bytes:
         """Invoke an OpenOCD command."""
@@ -235,8 +271,7 @@ class OpenOCDBackend(OCDBackend):
             return self._receive_response(decode=decode)
         except (BrokenPipeError, ConnectionResetError) as e:
             assert self._openocd_process is not None
-            _, err = self._openocd_process.communicate()
-            err = err.decode()
+            err = self._collect_stderr()
             log.debug(err)
             if "Error connecting DP: cannot read IDR" in err:
                 raise DebugProbeConnectionError(

--- a/gnwmanager/ocdbackend/pyocd_backend.py
+++ b/gnwmanager/ocdbackend/pyocd_backend.py
@@ -56,7 +56,10 @@ class PyOCDBackend(OCDBackend):
         name = self.probe.product_name
 
         lookup = {
-            "Picoprobe (CMSIS-DAP)": 10_000_000,
+            # Bit-banged SWD via RP2040 PIO, no level shifting. Hand-soldered
+            # G&W flying leads degrade fast above ~2 MHz (BAD_HASH_RAM_COMPRESSED).
+            # Matches the openocd backend's CMSIS-DAP default.
+            "Picoprobe (CMSIS-DAP)": 2_000_000,
             "STM32 STLink": 10_000_000,
             "CMSIS-DAP_LU": 500_000,
             "J-Link EDU": 15_000_000,

--- a/gnwmanager/ocdbackend/pyocd_backend.py
+++ b/gnwmanager/ocdbackend/pyocd_backend.py
@@ -57,9 +57,9 @@ class PyOCDBackend(OCDBackend):
 
         lookup = {
             # Bit-banged SWD via RP2040 PIO, no level shifting. Hand-soldered
-            # G&W flying leads degrade fast above ~2 MHz (BAD_HASH_RAM_COMPRESSED).
+            # G&W flying leads degrade fast past ~1 MHz (BAD_HASH_RAM_COMPRESSED).
             # Matches the openocd backend's CMSIS-DAP default.
-            "Picoprobe (CMSIS-DAP)": 2_000_000,
+            "Picoprobe (CMSIS-DAP)": 1_000_000,
             "STM32 STLink": 10_000_000,
             "CMSIS-DAP_LU": 500_000,
             "J-Link EDU": 15_000_000,

--- a/gnwmanager/ocdbackend/pyocd_backend.py
+++ b/gnwmanager/ocdbackend/pyocd_backend.py
@@ -14,6 +14,7 @@ with suppress(ImportError):
 class PyOCDBackend(OCDBackend):
     def __init__(self, connect_mode="attach"):
         super().__init__()
+        import pyocd
         from pyocd.core.helpers import ConnectHelper
         from pyocd.target import TARGET
 

--- a/gnwmanager/status.py
+++ b/gnwmanager/status.py
@@ -13,6 +13,7 @@ flashapp_status_enum_to_str = {
     0xBAD0000B: "BAD_SD_DIR",
     0xBAD0000C: "BAD_SD_LIST_TRUNC",
     0xBAD0000D: "BAD_SD_READ",
+    0xBAD0000E: "BAD_HASH_RAM_COMPRESSED",
     0xCAFE0000: "IDLE",
     0xCAFE0001: "ERASE",
     0xCAFE0002: "PROG",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ exclude_lines = [
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
+# Allow passing bytearray/memoryview where bytes is expected (pyright >=1.1.4xx
+# disables this promotion by default).
+disableBytesTypePromotions = false
 
 [tool.ruff]
 target-version = 'py38'

--- a/scripts/img2pixel.py
+++ b/scripts/img2pixel.py
@@ -25,8 +25,10 @@ def write_pixels(prefix, fn, invert=False):
         ]
 
         for x in range(img.width):
-            pixel = img.getpixel((x, y))
-            pixel = sum(pixel) / len(pixel)
+            raw = img.getpixel((x, y))
+            assert raw is not None
+            channels = raw if isinstance(raw, tuple) else (raw,)
+            pixel = sum(channels) / len(channels)
 
             if invert:
                 if pixel < 127:


### PR DESCRIPTION
# More robust transfers

Hardens the host↔device transfer protocol against signal-integrity and SD-card flakiness (which mostly showed up on hand-soldered/flying-lead probe setups), surfaces real failures instead of hanging or exiting cleanly, and shrinks the firmware along the way.

## Transfer robustness

- Verify the **compressed** buffer's SHA256 on-device before decompression, so transfer corruption surfaces as `BAD_HASH_RAM_COMPRESSED` instead of a misleading `BAD_DECOMPRESS`.
- **Chunk-level retry**: device parks and waits for the host to re-send the same context buffer on a bad compressed hash (up to 3 attempts per chunk) instead of failing the whole operation.
- **Operation-level retry**: if a `BAD_HASH_RAM*` error survives chunk retries, reload firmware and re-run the entire flash/sdpush (up to 2 retries).
- Drain posted writes (read-back after writing a context) so the device can't act on a stale `ready` flag before a large buffer has fully landed.
- **Adaptive no-progress timeouts** in all device wait loops: the deadline resets on any status change rather than a fixed wall-clock limit, so slow-but-progressing SD cards / long flashes no longer time out (effective idle budget raised 20s → 120s).

## Error surfacing

- Exit **non-zero** on `BAD_HASH_RAM*` / `BAD_HASH_FLASH` data corruption instead of exiting cleanly.
- Human-readable, colored error messages, e.g. *"Transfer corruption persisted after retries. Try lowering `--frequency` or check wiring."*
- Added `BAD_HASH_RAM_COMPRESSED` to the Python status mapping.

## SD-card reliability

- Retry transient CRC write errors (up to 3x/block) on both hardware- and software-SPI drivers; abort cleanly on genuine write errors.
- `SD_TxDataBlock` returns the full status token for finer error classification.
- Cleanly `f_mount(NULL, …)` after a failed open/write so FATFS state is fresh on retry.
- Longer power-off reset delay (5ms → 50ms) to fully discharge the SD slot after a crash.

## Probe / connection defaults

- Lower default CMSIS-DAP / picoprobe SWD speed to **1 MHz** (both OpenOCD and PyOCD backends) — high speeds over flying leads were the main source of `BAD_HASH_RAM_COMPRESSED`.
- Drain the OpenOCD stderr pipe in a background thread so a full OS buffer can't wedge OpenOCD mid-session (output still retained for error reporting).

## GUI / idle behavior

- Show the IDLE icon and stop the walking animation only when **truly** idle (status IDLE, no queued contexts, no upload/download in flight) — no more false "walking" or premature IDLE during active transfers.
- **B button** now also resets the device (easier to reach than the power button); the main-loop reset only fires when truly idle.

## Firmware size (~62KB → ~49KB, -21%)

- Stripped dead per-field RTC getters/setters; folded time conversion onto branchless `days_from_civil`/`civil_from_days` (drops newlib `mktime`/`gmtime`/timezone code).
- Replaced `localtime` in `get_fattime()` with direct RTC register reads; dropped `<time.h>` from FatFs diskio.
- Inlined the `snprintf` in SD directory listing; overrode `__assert_func` to avoid pulling in `fiprintf`.

## Misc

- MPU SRAM1 region expanded 512KB → 1MB and marked executable, so code can run from the full AXI SRAM.
- Progress bars now show a `desc=` label (filename / "patched firmware") for dump/flash/sdpush.
- CI: attach `firmware.bin`, `unlock.bin`, and `dist/*` to GitHub Releases on `v*.*.*` tag pushes.