### PR TITLE
Use PyPI trusted publishing for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # Needed to upload binaries to the GitHub Release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Needed for poetry-dynamic-versioning to read git tags
 
       - name: arm-none-eabi-gcc GNU Arm Embedded Toolchain
         uses: carlosperate/arm-none-eabi-gcc-action@v1.8.1
@@ -19,27 +21,12 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.8.5
           virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Configure Poetry
-        run: |
-          poetry self add poetry-dynamic-versioning[plugin]
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: poetry self add poetry-dynamic-versioning[plugin]
 
       - name: Build stm32 firmwares
         run: make -j4
@@ -47,12 +34,7 @@ jobs:
       - name: Build package
         run: poetry build
 
-      - name: Publish package
-        if: github.event_name != 'workflow_dispatch'
-        run: poetry publish
-
       - uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: dist
           path: dist/
@@ -65,3 +47,20 @@ jobs:
             gnwmanager/firmware.bin
             gnwmanager/unlock.bin
             dist/*
+
+  publish:
+    needs: build
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Trusted publishing to PyPI via OIDC
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gnwmanager
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Replace token-based publishing with OIDC trusted publishing. Split the deploy workflow into build and publish jobs, with the publish job using pypa/gh-action-pypi-publish under a dedicated pypi environment.