### PR TITLE
Autodetect lfs partition + geometry subcommand action

### DIFF
--- a/Core/Src/gnwmanager.c
+++ b/Core/Src/gnwmanager.c
@@ -44,7 +44,15 @@ enum gnwmanager_action {
     GNWMANAGER_ACTION_LIST_SD_DIR = 3,
     GNWMANAGER_ACTION_DELETE_FILE_FROM_SD = 4,
     GNWMANAGER_ACTION_READ_FILE_FROM_SD = 5,
+    GNWMANAGER_ACTION_SCAN_LFS = 6,
+    GNWMANAGER_ACTION_SCAN_GEOMETRY = 7,
 };
+
+typedef struct {
+    uint32_t address;
+    uint32_t size;
+    char type[16];
+} gnwmanager_partition_t;
 
 
 typedef struct {
@@ -470,6 +478,247 @@ static void gnwmanager_action_read_sd_file(work_context_t *context){
     context->response_ready = 1;
 }
 
+static inline bool safe_memcmp(volatile const uint8_t *p1, const uint8_t *p2, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (p1[i] != p2[i]) return false;
+    }
+    return true;
+}
+
+static bool is_lfs_superblock(uint32_t addr, uint32_t flash_size) {
+    if (addr < 0x90000000 || addr + 32 > 0x90000000 + flash_size) return false;
+    volatile const uint8_t *block = (volatile const uint8_t *)addr;
+    if (!safe_memcmp(block + 8, (const uint8_t *)"littlefs", 8)) return false;
+    uint32_t version = block[20] | (block[21] << 8) | (block[22] << 16) | (block[23] << 24);
+    uint32_t block_size = block[24] | (block[25] << 8) | (block[26] << 16) | (block[27] << 24);
+    uint32_t block_count = block[28] | (block[29] << 8) | (block[30] << 16) | (block[31] << 24);
+    return ((version >> 16) == 2 && block_size >= 128 && block_size <= 8192 && block_count > 0);
+}
+
+static void gnwmanager_action_scan_lfs(work_context_t *context) {
+    OSPI_EnableMemoryMappedMode();
+    uint32_t flash_size = OSPI_GetSize();
+    uint32_t mib = 1024 * 1024;
+    gnwmanager_partition_t *partitions = (gnwmanager_partition_t *)context->buffer;
+    uint32_t count = 0;
+    uint32_t max_count = (256 << 10) / sizeof(gnwmanager_partition_t);
+
+    // Scan backwards at 1MiB boundaries
+    for (uint32_t boundary = flash_size; boundary >= mib; boundary -= mib) {
+        uint32_t sb_addr = 0x90000000 + boundary - 4096;
+        if (is_lfs_superblock(sb_addr, flash_size)) {
+            const uint8_t *block = (const uint8_t *)sb_addr;
+            uint32_t block_size = block[24] | (block[25] << 8) | (block[26] << 16) | (block[27] << 24);
+            uint32_t block_count = block[28] | (block[29] << 8) | (block[30] << 16) | (block[31] << 24);
+            uint32_t p_size = block_size * block_count;
+
+            if (p_size > 0 && block_size > 0 && p_size <= flash_size && boundary >= p_size) {
+                uint32_t p_start = boundary - p_size;
+                if (p_start + p_size <= flash_size && (p_start % 4096 == 0)) {
+                    if (count < max_count) {
+                        partitions[count].address = p_start;
+                        partitions[count].size = p_size;
+                        strcpy(partitions[count].type, "LittleFS");
+                        count++;
+                    }
+                }
+            }
+        }
+    }
+    context->size = count * sizeof(gnwmanager_partition_t);
+    context->response_ready = 1;
+}
+
+static void gnwmanager_action_scan_geometry(work_context_t *context) {
+    OSPI_EnableMemoryMappedMode();
+    uint32_t flash_size = OSPI_GetSize();
+    gnwmanager_partition_t *partitions = (gnwmanager_partition_t *)context->buffer;
+    uint32_t count = 0;
+    uint32_t max_count = (256 << 10) / sizeof(gnwmanager_partition_t);
+
+    static const uint8_t mario_int_sig[] = {0x30, 0x13, 0x01, 0x20};
+    static const uint8_t zelda_int_sig[] = {0x20, 0xb6, 0x01, 0x20};
+    static const uint8_t zelda_stock_sig[] = {0x3C, 0x13, 0x96, 0xC5, 0x79, 0x38, 0x71, 0xD6};
+    static const uint8_t zelda_patched_sig[] = {0x22, 0x21, 0x23, 0x22, 0x22, 0x22, 0x22, 0x22};
+    static const uint8_t mario_stock_sig[] = {0xFE, 0x6E, 0xF8, 0x01, 0x30, 0x77, 0x2D, 0x3A};
+    static const uint8_t mario_patched_sig[] = {0x78, 0xD8, 0xA9, 0x10, 0x8D, 0x00, 0x20, 0xA2};
+
+    // 2. External Flash Check
+    uint32_t strides[] = {1024 * 1024, 512 * 1024, 256 * 1024, 128 * 1024, 64 * 1024};
+
+    for (int s = 0; s < 5; s++) {
+        uint32_t stride = strides[s];
+        for (uint32_t addr = 0; addr <= flash_size; addr += stride) {
+            // Geometric skip: skip addresses already covered by a larger stride
+            if (stride < 1024 * 1024 && (addr % (stride * 2) == 0)) continue;
+
+            uint32_t phys_addr = addr;
+            uint32_t mapped_addr = 0x90000000 + phys_addr;
+            volatile const uint8_t *sector = (volatile const uint8_t *)mapped_addr;
+
+            bool is_lfs = false;
+
+            // LittleFS Check (Forward: superblock at phys_addr)
+            if (is_lfs_superblock(mapped_addr, flash_size)) {
+                is_lfs = true;
+                uint32_t anchor_addr = phys_addr;
+                if (phys_addr + 4096 + 32 <= flash_size && is_lfs_superblock(mapped_addr + 4096, flash_size)) {
+                    anchor_addr = phys_addr + 4096;
+                }
+
+                volatile const uint8_t *block = (volatile const uint8_t *)(0x90000000 + anchor_addr);
+                uint32_t bsize = block[24] | (block[25] << 8) | (block[26] << 16) | (block[27] << 24);
+                uint32_t bcount = block[28] | (block[29] << 8) | (block[30] << 16) | (block[31] << 24);
+                uint32_t p_size = bsize * bcount;
+                if (p_size > 0 && bsize > 0 && p_size <= flash_size && anchor_addr + bsize >= p_size) {
+                    uint32_t p_start = (anchor_addr + bsize) - p_size;
+                    if (p_start + p_size <= flash_size && (p_start % 4096 == 0)) {
+                        bool exists = false;
+                        for (uint32_t i = 0; i < count; i++) {
+                            if (p_start == partitions[i].address && p_size == partitions[i].size) {
+                                exists = true; break;
+                            }
+                        }
+                        if (!exists && count < max_count) {
+                            partitions[count].address = p_start;
+                            partitions[count].size = p_size;
+                            strcpy(partitions[count].type, "LittleFS");
+                            count++;
+                        }
+                    }
+                }
+            }
+            // LittleFS Check (Inverted: superblock at phys_addr - 4096)
+            else if (phys_addr >= 4096 && is_lfs_superblock(mapped_addr - 4096, flash_size)) {
+                is_lfs = true;
+                uint32_t anchor_addr = phys_addr - 4096;
+                volatile const uint8_t *block = (volatile const uint8_t *)(0x90000000 + anchor_addr);
+                uint32_t bsize = block[24] | (block[25] << 8) | (block[26] << 16) | (block[27] << 24);
+                uint32_t bcount = block[28] | (block[29] << 8) | (block[30] << 16) | (block[31] << 24);
+                uint32_t p_size = bsize * bcount;
+                if (p_size > 0 && bsize > 0 && p_size <= flash_size && anchor_addr + bsize >= p_size) {
+                    uint32_t p_start = (anchor_addr + bsize) - p_size;
+                    if (p_start + p_size <= flash_size && (p_start % 4096 == 0)) {
+                        bool exists = false;
+                        for (uint32_t i = 0; i < count; i++) {
+                            if (p_start == partitions[i].address && p_size == partitions[i].size) {
+                                exists = true; break;
+                            }
+                        }
+                        if (!exists && count < max_count) {
+                            partitions[count].address = p_start;
+                            partitions[count].size = p_size;
+                            strcpy(partitions[count].type, "LittleFS");
+                            count++;
+                        }
+                    }
+                }
+            }
+
+            if (is_lfs) continue;
+
+            // Coverage skip: skip addresses already identified as being inside a partition
+            bool covered = false;
+            for (uint32_t i = 0; i < count; i++) {
+                if (addr >= partitions[i].address && addr < partitions[i].address + partitions[i].size) {
+                    covered = true; break;
+                }
+            }
+            if (covered) continue;
+            // FAT Check
+            else if (phys_addr + 512 <= flash_size && sector[510] == 0x55 && sector[511] == 0xAA && (sector[0] == 0xEB || sector[0] == 0xE9)) {
+                uint32_t bps   = sector[0x0B] | (sector[0x0C] << 8);
+                uint32_t tot16 = sector[0x13] | (sector[0x14] << 8);
+                uint32_t tot32 = sector[0x20] | (sector[0x21] << 8) | (sector[0x22] << 16) | (sector[0x23] << 24);
+                uint32_t total_sectors = tot16 ? tot16 : tot32;
+                if (bps >= 512 && bps <= 4096 && total_sectors) {
+                    uint32_t p_size = total_sectors * bps;
+                    if (count < max_count) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = p_size;
+                        strcpy(partitions[count].type, "FAT");
+                        count++;
+                    }
+                }
+            }
+            // FrogFS check
+            else if (phys_addr + 12 <= flash_size && safe_memcmp(sector, (const uint8_t *)"FROG", 4)) {
+                uint32_t bin_sz = sector[8] | (sector[9] << 8) | (sector[10] << 16) | (sector[11] << 24);
+                if (count < max_count) {
+                    partitions[count].address = phys_addr;
+                    partitions[count].size = bin_sz;
+                    strcpy(partitions[count].type, "FrogFS");
+                    count++;
+                }
+            }
+            // Internal Flash Backup Check
+            else if (phys_addr + 131072 <= flash_size && (safe_memcmp(sector, mario_int_sig, 4) || safe_memcmp(sector, zelda_int_sig, 4))) {
+                if (safe_memcmp(sector, mario_int_sig, 4)) {
+                    if (count < max_count) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = 131072;
+                        if (sector[131071] == 0xFF) {
+                            strcpy(partitions[count].type, "Mario OFW (Int)");
+                        } else {
+                            strcpy(partitions[count].type, "Mario Pat(Int)");
+                        }
+                        count++;
+                    }
+                }
+                else if (safe_memcmp(sector, zelda_int_sig, 4)) {
+                    if (count < max_count) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = 131072;
+                        if (sector[131071] == 0xFF) {
+                            strcpy(partitions[count].type, "Zelda OFW (Int)");
+                        } else {
+                            strcpy(partitions[count].type, "Zelda Pat(Int)");
+                        }
+                        count++;
+                    }
+                }
+            }
+            // Asset Blobs Check
+            else if (phys_addr + 8 <= flash_size) {
+                if (safe_memcmp(sector, zelda_stock_sig, 8)) {
+                    if (count < max_count && phys_addr + 4 * 1024 * 1024 <= flash_size) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = 4 * 1024 * 1024;
+                        strcpy(partitions[count].type, "Zelda OFW");
+                        count++;
+                    }
+                }
+                else if (safe_memcmp(sector, zelda_patched_sig, 8)) {
+                    if (count < max_count && phys_addr >= 0x20000 && (phys_addr - 0x20000 + 4 * 1024 * 1024 <= flash_size)) {
+                        partitions[count].address = phys_addr - 0x20000;
+                        partitions[count].size = 4 * 1024 * 1024;
+                        strcpy(partitions[count].type, "Zelda Assets");
+                        count++;
+                    }
+                }
+                else if (safe_memcmp(sector, mario_stock_sig, 8)) {
+                    if (count < max_count && phys_addr + 1 * 1024 * 1024 <= flash_size) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = 1 * 1024 * 1024;
+                        strcpy(partitions[count].type, "Mario OFW");
+                        count++;
+                    }
+                }
+                else if (safe_memcmp(sector, mario_patched_sig, 8)) {
+                    if (count < max_count && phys_addr + 1 * 1024 * 1024 <= flash_size) {
+                        partitions[count].address = phys_addr;
+                        partitions[count].size = 1 * 1024 * 1024;
+                        strcpy(partitions[count].type, "Mario Assets");
+                        count++;
+                    }
+                }
+            }
+        }
+    }
+    context->size = count * sizeof(gnwmanager_partition_t);
+    context->response_ready = 1;
+}
+
 static bool ext_is_erased(uint32_t offset, uint32_t size){
     OSPI_EnableMemoryMappedMode();
     uint32_t *end = (uint32_t *)(0x90000000 + offset + size);
@@ -550,6 +799,14 @@ static void gnwmanager_run(void)
             case GNWMANAGER_ACTION_READ_FILE_FROM_SD:
                 gnwmanager_set_status(GNWMANAGER_STATUS_PROG);
                 gnwmanager_action_read_sd_file(source_context);
+                return;
+            case GNWMANAGER_ACTION_SCAN_LFS:
+                gnwmanager_set_status(GNWMANAGER_STATUS_PROG);
+                gnwmanager_action_scan_lfs(source_context);
+                return;
+            case GNWMANAGER_ACTION_SCAN_GEOMETRY:
+                gnwmanager_set_status(GNWMANAGER_STATUS_PROG);
+                gnwmanager_action_scan_geometry(source_context);
                 return;
             case GNWMANAGER_ACTION_WRITE_FILE_TO_SD:
                 state = GNWMANAGER_IDLE_SD;

--- a/gnwmanager/cli/__init__.py
+++ b/gnwmanager/cli/__init__.py
@@ -4,6 +4,7 @@ from gnwmanager.cli._dump import dump
 from gnwmanager.cli._erase import erase
 from gnwmanager.cli._filesystem import (
     format,
+    geometry,
     ls,
     mkdir,
     mv,

--- a/gnwmanager/cli/_filesystem.py
+++ b/gnwmanager/cli/_filesystem.py
@@ -269,3 +269,34 @@ def rm(
     gnw.start_gnwmanager()
     fs = gnw.filesystem(offset=offset)
     fs.remove(path.as_posix(), recursive=recursive)
+
+
+@app.command(group="Filesystem")
+def geometry(
+    *,
+    gnw: GnWType,
+):
+    """List all detected partitions on the external flash."""
+    from gnwmanager.filesystem import _test_lfs_integrity
+    
+    gnw.start_gnwmanager()
+    partitions = gnw.scan_geometry()
+
+    if not partitions:
+        print("No partitions detected.")
+        return
+
+    print(f"{'Address':<12} {'Size':<12} {'Type':<30} {'Notes':<20}")
+    print("-" * 76)
+    for p in partitions:
+        notes = ""
+        if p.type == "LittleFS":
+            if _test_lfs_integrity(gnw, p):
+                notes = "Active/Intact"
+            else:
+                notes = "Corrupt/Stale"
+        if p.size < 1024 * 1024:
+            size_str = f"{p.size / 1024:g}KB"
+        else:
+            size_str = f"{p.size / (1024 * 1024):g}MB"
+        print(f"0x{p.address:08X} {size_str:<12} {p.type:<30} {notes:<20}")

--- a/gnwmanager/cli/main.py
+++ b/gnwmanager/cli/main.py
@@ -17,7 +17,7 @@ from littlefs.errors import LittleFSError
 from gnwmanager import __version__
 from gnwmanager.cli._parsers import GnWType, OffsetType, int_parser
 from gnwmanager.cli.devices import AutodetectError, DeviceModel
-from gnwmanager.exceptions import DataError, DebugProbeConnectionError
+from gnwmanager.exceptions import DataError, DebugProbeConnectionError, TooManyLFSPartitionsFoundError, MissingThirdPartyError
 from gnwmanager.gnw import GnW
 from gnwmanager.ocdbackend import OCDBackend
 
@@ -115,6 +115,21 @@ def info(
     _display("External Flash Size (MB):", str(gnw.external_flash_size / (1 << 20)))
     _display("Locked?: ", "LOCKED" if gnw.is_locked() else "UNLOCKED")
 
+    partitions = gnw.scan_geometry()
+    if partitions:
+        from gnwmanager.filesystem import _test_lfs_integrity
+        p_strs = []
+        for p in partitions:
+            ptype = p.type.replace(" (Patched)", "")
+            if p.type == "LittleFS" and not _test_lfs_integrity(gnw, p):
+                p_strs.append(f"{ptype} (Corrupt)")
+            else:
+                if p.size < 1024 * 1024:
+                    p_strs.append(f"{ptype} ({p.size / 1024:g}KB)")
+                else:
+                    p_strs.append(f"{ptype} ({p.size / (1024 * 1024):g}MB)")
+        _display("Partitions:", ", ".join(p_strs))
+
     try:
         fs = gnw.filesystem(offset=offset, block_count=0)
     except LittleFSError as e:
@@ -122,10 +137,17 @@ def info(
             fs_size = "MISSING/CORRUPT"
         else:
             raise
+    except Exception as e:
+        from gnwmanager.exceptions import TooManyLFSPartitionsFoundError
+        if isinstance(e, TooManyLFSPartitionsFoundError):
+            fs_size = "AMBIGUOUS (Multiple valid LFS partitions)"
+        else:
+            raise
     else:
         fs_stat = fs.fs_stat()
         fs_size_bytes = fs_stat.block_count * fs_stat.block_size
-        fs_size = f"{fs_stat.block_size} * {fs_stat.block_count} ({fs_size_bytes})"
+        p_addr = fs.context.filesystem_end - fs_size_bytes
+        fs_size = f"{fs_stat.block_size} * {fs_stat.block_count} ({fs_size_bytes} @0x{p_addr:08X})"
 
     _display("Filesystem Size (B):", fs_size)
 
@@ -245,6 +267,11 @@ def main(
                 additional_kwargs["gnw"] = gnw
 
             command(*bound.args, **bound.kwargs, **additional_kwargs)
+    except (TooManyLFSPartitionsFoundError, MissingThirdPartyError) as e:
+        rich.print(f"[red]{e}[/red]")
+        close_on_exit = False
+        if exit_on_error:
+            sys.exit(1)
     except DebugProbeConnectionError as e:
         rich.print(f"[red]Error communicating with device ({e}). Is it ON and connected?[/red]")
         close_on_exit = False
@@ -284,6 +311,7 @@ def main(
     finally:
         if close_on_exit and gnw is not None:
             gnw.backend.close()
+
 
 
 def run_app():

--- a/gnwmanager/exceptions.py
+++ b/gnwmanager/exceptions.py
@@ -8,3 +8,7 @@ class DataError(Exception):
 
 class MissingThirdPartyError(Exception):
     """A required external library/executable is missing."""
+
+
+class TooManyLFSPartitionsFoundError(Exception):
+    """Multiple valid LittleFS partitions were found."""

--- a/gnwmanager/filesystem.py
+++ b/gnwmanager/filesystem.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
@@ -7,27 +8,89 @@ from littlefs.context import UserContext
 from littlefs.errors import LittleFSError
 from littlefs.lfs import LFSConfig
 
-from gnwmanager.gnw import GnW
+from gnwmanager.gnw import GnW, Partition
 from gnwmanager.utils import sha256
 from gnwmanager.validation import validate_extflash_offset
+from gnwmanager.exceptions import TooManyLFSPartitionsFoundError
+
+log = logging.getLogger(__name__)
 
 _gnw_cache = {}
 
 
+def _test_lfs_integrity(gnw: GnW, partition: Partition, max_nodes: int = 50) -> bool:
+    """Safely test LittleFS structural integrity with a read-only mount and bounded walk.
+
+    Parameters
+    ----------
+    gnw: GnW
+        Game and Watch object.
+    partition: Partition
+        The partition candidate to test.
+    max_nodes: int
+        Maximum number of filesystem nodes to traverse before passing the integrity check.
+        If a partition is corrupt, it usually fails during mount or within the first few nodes.
+
+    Returns
+    -------
+    bool
+        True if the filesystem appears intact, False if LFS_ERR_CORRUPT is encountered.
+    """
+    filesystem_end = partition.address + partition.size
+    # Create a fresh cache specifically for this test so we don't pollute the main one
+    test_cache = {}
+    lfs_context = LfsDriverContext(gnw, filesystem_end, cache=test_cache, read_only=True)
+
+    fs = LittleFS(
+        lfs_context,
+        block_size=gnw.external_flash_block_size,
+        block_count=partition.size // gnw.external_flash_block_size,
+        block_cycles=500,
+        mount=False,
+    )
+
+    try:
+        fs.mount()
+    except LittleFSError as e:
+        if e.code == LittleFSError.Error.LFS_ERR_CORRUPT:
+            log.debug(f"Partition at 0x{partition.address:X} failed mount integrity check.")
+            return False
+        raise
+
+    nodes_checked = 0
+    try:
+        for root, dirs, files in fs.walk("/"):
+            for name in dirs + files:
+                # Reading the stat forces LittleFS to traverse the node's metadata
+                fs.stat((Path(root) / name).as_posix())
+                nodes_checked += 1
+                if nodes_checked >= max_nodes:
+                    return True
+    except LittleFSError as e:
+        if e.code == LittleFSError.Error.LFS_ERR_CORRUPT:
+            log.debug(f"Partition at 0x{partition.address:X} failed deep integrity check at node {nodes_checked}.")
+            return False
+        raise
+
+    return True
+
+
 class LfsDriverContext(UserContext):
-    def __init__(self, gnw: GnW, filesystem_end: int, cache: Optional[dict] = None) -> None:
+    def __init__(self, gnw: GnW, filesystem_end: int, cache: Optional[dict] = None, read_only: bool = False) -> None:
         validate_extflash_offset(filesystem_end)
 
         self.gnw = gnw
         self.filesystem_end = filesystem_end
         self.cache = _gnw_cache if cache is None else cache
+        self.read_only = read_only
 
     def read(self, cfg: LFSConfig, block: int, off: int, size: int) -> bytearray:
         try:
             return bytearray(self.cache[block][off : off + size])
         except KeyError:
             pass
-        self.gnw.wait_for_all_contexts_complete()  # if a prog/erase is being performed, chip is not in memory-mapped-mode
+        if not self.read_only:
+            self.gnw.wait_for_all_contexts_complete()  # if a prog/erase is being performed, chip is not in memory-mapped-mode
         addr = 0x9000_0000 + self.filesystem_end - ((block + 1) * cfg.block_size)
         self.cache[block] = bytearray(self.gnw.read_memory(addr, size))
         return bytearray(self.cache[block][off : off + size])
@@ -40,15 +103,17 @@ class LfsDriverContext(UserContext):
         except KeyError:
             pass
 
-        addr = self.filesystem_end - ((block + 1) * cfg.block_size) + off
-        self.gnw.program(0, addr, data, erase=False)
+        if not self.read_only:
+            addr = self.filesystem_end - ((block + 1) * cfg.block_size) + off
+            self.gnw.program(0, addr, data, erase=False)
 
         return 0
 
     def erase(self, cfg: LFSConfig, block: int) -> int:
         self.cache[block] = bytearray([0xFF] * cfg.block_size)
-        offset = self.filesystem_end - ((block + 1) * cfg.block_size)
-        self.gnw.erase(0, offset, cfg.block_size)
+        if not self.read_only:
+            offset = self.filesystem_end - ((block + 1) * cfg.block_size)
+            self.gnw.erase(0, offset, cfg.block_size)
         return 0
 
     def sync(self, cfg: LFSConfig) -> int:
@@ -72,6 +137,22 @@ def get_filesystem(gnw: GnW, offset: int = 0, block_count=0, mount=True) -> Litt
         Mount the filesystem.
     """
     filesystem_end = gnw.external_flash_size - offset
+    if offset == 0:
+        candidates = [p for p in gnw.scan_geometry() if p.type == "LittleFS"]
+        valid_partitions = []
+        if candidates:
+            for p in candidates:
+                if _test_lfs_integrity(gnw, p):
+                    valid_partitions.append(p)
+
+            if len(valid_partitions) > 1:
+                raise TooManyLFSPartitionsFoundError(
+                    "Multiple valid LittleFS partitions detected (likely from moving to an SD layout "
+                    "without erasing flash). Please specify which one to use with --offset."
+                )
+            elif len(valid_partitions) == 1:
+                filesystem_end = valid_partitions[0].address + valid_partitions[0].size
+
     lfs_context = LfsDriverContext(gnw, filesystem_end)
 
     fs = LittleFS(

--- a/gnwmanager/gnw.py
+++ b/gnwmanager/gnw.py
@@ -44,6 +44,24 @@ _MAX_TRANSFER_RETRIES = 2
 _MAX_CHUNK_RETRIES = 3
 
 
+class Partition(NamedTuple):
+    address: int
+    size: int
+    type: str
+
+
+_PTYPE_MAP = {
+    "Zelda OFW": "Zelda Assets",
+    "Zelda Assets": "Zelda Assets (Patched)",
+    "Mario OFW": "Mario Assets",
+    "Mario Assets": "Mario Assets (Patched)",
+    "Zelda OFW (Int)": "Zelda OFW",
+    "Zelda Pat(Int)": "Zelda OFW (Patched)",
+    "Mario OFW (Int)": "Mario OFW",
+    "Mario Pat(Int)": "Mario OFW (Patched)",
+}
+
+
 def _is_transfer_corruption_error(exc: "DataError") -> bool:
     if not exc.args or not isinstance(exc.args[0], str):
         return False
@@ -57,6 +75,8 @@ actions: dict[str, int] = {
     "LIST_SD_DIR": 3,
     "DELETE_FILE_FROM_SD": 4,
     "READ_FILE_FROM_SD": 5,
+    "SCAN_LFS": 6,
+    "SCAN_GEOMETRY": 7,
 }
 
 _comm: dict[str, Variable] = {
@@ -1036,11 +1056,71 @@ class GnW:
             log.warning("SD directory listing was truncated (output larger than 256 KiB).")
         return data.decode("utf-8", errors="replace")
 
+    def scan_lfs(self) -> List[Partition]:
+        """Auto-detect LittleFS partition candidates using the device-side scanner."""
+        context = self.get_context()
+        self.write_uint32(context["response_ready"], 0)
+        self.write_uint32(context["action"], actions["SCAN_LFS"])
+        self._drain_pending_writes(context)
+        self.write_uint32(context["ready"], self.context_counter)
+        self.context_counter += 1
+
+        self.wait_for_context_response(context)
+        nbytes = self.read_uint32(context["size"])
+        if nbytes == 0:
+            self.write_uint32(context["ready"], 0)
+            return []
+
+        data = self.read_memory(context["buffer"], nbytes)
+        self.write_uint32(context["ready"], 0)
+
+        partitions = []
+        for i in range(0, len(data), 24):
+            chunk = data[i : i + 24]
+            if len(chunk) < 24:
+                break
+            addr = int.from_bytes(chunk[0:4], "little")
+            size = int.from_bytes(chunk[4:8], "little")
+            ptype = chunk[8:24].rstrip(b"\x00").decode("utf-8")
+            ptype = _PTYPE_MAP.get(ptype, ptype)
+            partitions.append(Partition(addr, size, ptype))
+
+        return partitions
+
+    def scan_geometry(self) -> List[Partition]:
+        """Scan the entire flash for partitions using the device-side scanner."""
+        context = self.get_context()
+        self.write_uint32(context["response_ready"], 0)
+        self.write_uint32(context["action"], actions["SCAN_GEOMETRY"])
+        self._drain_pending_writes(context)
+        self.write_uint32(context["ready"], self.context_counter)
+        self.context_counter += 1
+
+        self.wait_for_context_response(context)
+        nbytes = self.read_uint32(context["size"])
+        data = self.read_memory(context["buffer"], nbytes) if nbytes else b""
+        self.write_uint32(context["ready"], 0)
+
+        partitions = []
+        # Each gnwmanager_partition_t is 4+4+16 = 24 bytes
+        for i in range(0, len(data), 24):
+            chunk = data[i : i + 24]
+            if len(chunk) < 24:
+                break
+            addr = int.from_bytes(chunk[0:4], "little")
+            size = int.from_bytes(chunk[4:8], "little")
+            ptype = chunk[8:24].rstrip(b"\x00").decode("utf-8")
+            ptype = _PTYPE_MAP.get(ptype, ptype)
+            partitions.append(Partition(addr, size, ptype))
+        partitions.sort(key=lambda p: p.address)
+        return partitions
+
     def start_gnwmanager(self, force=False, resume=True):
         if not force and self._gnwmanager_started:
             return
 
         self.reset_and_halt()
+        self.reset_context_counter()
 
         firmware = (importlib.resources.files("gnwmanager") / "firmware.bin").read_bytes()
         log.debug(f"Loaded {len(firmware)} bytes of gnwmanager firmware.")


### PR DESCRIPTION
This commit adds more robust LFS partition detection and a general partition geometry scanner that runs on-device by quickly checking for known signatures/partition data. 

- Add on-device flash geometry scan action to query stock/patched assets and OFW backups, FAT, FrogFS, and LittleFS partitions.
- Scan geometry up to the end of flash, scanning for both forward and inverted LittleFS partition superblocks.
- All LFS candidates, including overlapping or corrupt ones, are fully listed.
- Only perform filesystem actions on a valid LFS partition
- Multiple valid LFS partitions raise TooManyLFSPartitionsFoundError and explicitly tell the user to use "--offset" to specify which should be used (rare edge case)
- Display LFS integrity test results (Active/Intact vs Corrupt/Stale) in geometry command notes and cleanly format output column widths.


<img width="2217" height="732" alt="image" src="https://github.com/user-attachments/assets/ee70a335-28ea-444d-bfc7-11a3af6ca743" />
