### PR TITLE
Add GDB backend (for QEMU)

### DIFF
--- a/gnwmanager/cli/main.py
+++ b/gnwmanager/cli/main.py
@@ -203,7 +203,9 @@ def _setup_logging(verbosity):
 @app.meta.default
 def main(
     *tokens: Annotated[str, Parameter(show=False, allow_leading_hyphen=True)],
-    backend: Annotated[Literal["openocd", "pyocd"], Parameter(name=["--backend", "-b"])] = "openocd",
+    backend: Annotated[Literal["openocd", "pyocd", "gdb"], Parameter(name=["--backend", "-b"])] = "openocd",
+    gdb_host: Annotated[str, Parameter(name=["--gdb-host"])] = "localhost",
+    gdb_port: Annotated[int, Parameter(name=["--gdb-port"])] = 1234,
     frequency: Annotated[Optional[int], Parameter(name=["--frequency", "-f"], converter=int_parser)] = None,
     verbosity: Annotated[
         Literal["debug", "info", "warning", "error"], Parameter(env_var="GNWMANAGER_VERBOSITY")
@@ -216,7 +218,11 @@ def main(
     Parameters
     ----------
     backend
-        Underlying on-chip-debugger backend to use.
+        Underlying on-chip-debugger backend to use. Use "gdb" to connect to a QEMU instance's gdbstub.
+    gdb_host
+        Host to connect to when using the "gdb" backend.
+    gdb_port
+        Port to connect to when using the "gdb" backend.
     frequency
         Debug probe frequency. Defaults to a typically reasonable fast value.
     """
@@ -238,7 +244,8 @@ def main(
 
             if "gnw" in ignored:
                 if gnw is None:
-                    gnw = GnW(OCDBackend[backend]())
+                    backend_kwargs = {"host": gdb_host, "port": gdb_port} if backend == "gdb" else {}
+                    gnw = GnW(OCDBackend[backend](**backend_kwargs))
                     gnw.backend.open()
                     if frequency is not None:
                         gnw.backend.set_frequency(frequency)

--- a/gnwmanager/ocdbackend/__init__.py
+++ b/gnwmanager/ocdbackend/__init__.py
@@ -1,3 +1,4 @@
 from .base import OCDBackend, TransferErrors
+from .gdb_backend import GDBBackend
 from .openocd_backend import OpenOCDBackend
 from .pyocd_backend import PyOCDBackend

--- a/gnwmanager/ocdbackend/gdb_backend.py
+++ b/gnwmanager/ocdbackend/gdb_backend.py
@@ -1,0 +1,287 @@
+import os
+import socket
+from time import sleep
+
+from gnwmanager.exceptions import DebugProbeConnectionError
+from gnwmanager.ocdbackend.base import OCDBackend, TransferErrors
+
+class GDBError(DebugProbeConnectionError):
+    pass
+
+TransferErrors.add(GDBError)
+
+def _checksum(data: bytes) -> bytes:
+    c = sum(data) % 256
+    return f"{c:02x}".encode("ascii")
+
+class GDBBackend(OCDBackend):
+    def __init__(self, host: str = "localhost", port: int = 1234):
+        super().__init__()
+        self.version = (0, 0, 0)
+        self.host = host
+        self.port = port
+        self._socket = None
+        self._is_running = False
+
+    def open(self) -> OCDBackend:
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.settimeout(5.0)
+        # The GDB remote protocol here is dominated by tiny packets waiting
+        # on each other's replies (a single-byte '+' ack, a short "m<addr>,4"
+        # read). Without this, Nagle's algorithm on this socket combines with
+        # the peer's delayed-ACK timer to add a fixed ~40ms stall to every
+        # single request/response round trip -- measured directly against
+        # qemu-gnw's gdbstub (a `gnwmanager --qemu info` call went from ~6.7s,
+        # matching real hardware over OpenOCD, to ~39s with this unset).
+        self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        try:
+            self._socket.connect((self.host, self.port))
+            self._sock_file = self._socket.makefile("rb", buffering=8192)
+        except (OSError, ConnectionRefusedError) as e:
+            raise DebugProbeConnectionError(f"Could not connect to QEMU GDB server at {self.host}:{self.port}. Is QEMU running with '-gdb tcp::{self.port}'?") from e
+        
+        # Initial handshake: Tell GDB stub what we support
+        try:
+            self._send_command(b"qSupported:multiprocess+;xmlRegisters=i386;qRelocInsn+")
+        except GDBError:
+            pass  # Some very simple stubs might not support qSupported
+            
+        # QEMU's GDB stub halts the VM when a client connects.
+        # We explicitly resume it to match physical probe behavior.
+        self.resume()
+            
+        return self
+
+    def close(self):
+        if self._socket:
+            if hasattr(self, '_sock_file') and self._sock_file:
+                self._sock_file.close()
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+            self._socket = None
+
+    def _send_command(self, cmd: bytes) -> bytes:
+        if not self._socket:
+            raise GDBError("Socket is not open")
+        
+        packet = b"$" + cmd + b"#" + _checksum(cmd)
+        self._socket.sendall(packet)
+        
+        # Wait for ack '+'
+        while True:
+            c = self._sock_file.read(1)
+            if not c:
+                raise GDBError("Connection closed by remote")
+            if c == b'+':
+                break
+            elif c == b'-':
+                self._socket.sendall(packet)
+            elif c == b'$':
+                # We got a packet instead of an ack. It's likely an asynchronous stop reply.
+                # We need to read it, ack it, and then keep waiting for our ack or response.
+                self._read_packet_data()
+                
+        # Wait for the actual reply packet
+        while True:
+            reply = self._wait_for_packet()
+            # If it's a stop reply (T, S, W, X) and we didn't ask for it (cmd wasn't ? or vCont etc)
+            # then it's an asynchronous notification. We should probably return it if we asked for it,
+            # or ignore it if it's out of band.
+            # For simplicity, if cmd is '?', we return the stop reply.
+            if cmd == b'?' or not reply.startswith((b'T', b'S', b'W', b'X')):
+                break
+            # Otherwise we ignore the out-of-band stop reply and wait for the real reply
+            
+        if reply.startswith(b'E'):
+            err_code = reply[1:].decode("ascii")
+            raise GDBError(f"GDB error response: {err_code} for command {cmd.decode('ascii', errors='ignore')}")
+            
+        return reply
+
+    def _read_packet_data(self) -> bytes:
+        # Assuming '$' was just read
+        reply = bytearray()
+        while True:
+            c = self._sock_file.read(1)
+            if not c:
+                raise GDBError("Connection closed by remote")
+            if c == b'#':
+                break
+            reply.extend(c)
+        # read checksum
+        self._sock_file.read(2)
+        # Send ack
+        self._socket.sendall(b'+')
+        return bytes(reply)
+
+    def _wait_for_packet(self) -> bytes:
+        while True:
+            c = self._sock_file.read(1)
+            if not c:
+                raise GDBError("Connection closed by remote")
+            if c == b'$':
+                return self._read_packet_data()
+            # Ignore anything else before '$'
+
+    def read_memory(self, addr: int, size: int) -> bytes:
+        if size == 0:
+            return b""
+
+        # Deliberately does NOT halt/resume around this like the other
+        # accessors below: qemu-gnw's gdbstub (gdbstub/gdbstub.c, see
+        # "Commit gdbstub memory-read/write non-halting fix") only gates
+        # the halt-while-running check for commands other than plain 'm'/'M'
+        # memory read/write -- those are serviced via cpu_memory_rw_debug(),
+        # which is exactly as safe to call from a running VM as a halted
+        # one. GDBBackend is QEMU-only (see cli/main.py: only ever
+        # instantiated when --qemu is set; real hardware goes through
+        # OCDBackend/OpenOCDBackend instead), so this is always talking to
+        # that patched gdbstub. Halting/resuming around every single read
+        # was previously adding two full GDB round-trips (each bounded by
+        # this socket's 5s timeout, retried up to 5x by callers like
+        # stm32h7b0-diag's harness.py) to every poll of a status flag --
+        # confirmed root cause of multi-minute-to-hour diag-tool runs that
+        # should take seconds under a heavily-loaded (near-100%-CPU) vCPU.
+        CHUNK_SIZE = 4096
+        result = bytearray()
+
+        for offset in range(0, size, CHUNK_SIZE):
+            chunk_size = min(CHUNK_SIZE, size - offset)
+            cmd = f"m{(addr + offset):x},{chunk_size:x}".encode("ascii")
+            reply = self._send_command(cmd)
+            result.extend(bytes.fromhex(reply.decode("ascii")))
+
+        return bytes(result)
+
+    def write_memory(self, addr: int, data: bytes):
+        if not data:
+            return
+
+        # See read_memory()'s comment: 'M' is exempted from the halt gate
+        # by the same qemu-gnw gdbstub patch, so no halt/resume needed here
+        # either.
+        CHUNK_SIZE = 4096
+        for offset in range(0, len(data), CHUNK_SIZE):
+            chunk = data[offset:offset+CHUNK_SIZE]
+            hex_data = chunk.hex()
+            cmd = f"M{(addr + offset):x},{len(chunk):x}:{hex_data}".encode("ascii")
+            reply = self._send_command(cmd)
+
+            if reply != b"OK":
+                raise GDBError(f"Failed to write memory, expected OK got {reply}")
+
+    def _get_reg_idx(self, name: str) -> int:
+        name = name.lower()
+        mapping = {
+            "sp": 13,
+            "msp": 13,
+            "lr": 14,
+            "pc": 15,
+            "xpsr": 16,
+        }
+        if name in mapping:
+            return mapping[name]
+        if name.startswith("r"):
+            try:
+                return int(name[1:])
+            except ValueError:
+                pass
+        raise ValueError(f"Unknown register {name}")
+
+    def read_register(self, name: str) -> int:
+        was_running = self._is_running
+        if was_running:
+            self.halt()
+            
+        idx = self._get_reg_idx(name)
+        cmd = f"p{idx:x}".encode("ascii")
+        reply = self._send_command(cmd)
+        
+        if was_running:
+            self.resume()
+            
+        # GDB returns little-endian hex string for registers usually
+        data = bytes.fromhex(reply.decode("ascii"))
+        return int.from_bytes(data, byteorder="little")
+
+    def write_register(self, name: str, val: int):
+        was_running = self._is_running
+        if was_running:
+            self.halt()
+            
+        idx = self._get_reg_idx(name)
+        # 32-bit registers, little-endian hex string
+        hex_val = val.to_bytes(4, byteorder="little").hex()
+        cmd = f"P{idx:x}={hex_val}".encode("ascii")
+        reply = self._send_command(cmd)
+        
+        if was_running:
+            self.resume()
+            
+        if reply != b"OK":
+            raise GDBError(f"Failed to write register, expected OK got {reply}")
+
+    def set_frequency(self, freq: int):
+        # Ignored for emulated environment
+        pass
+
+    def reset(self):
+        was_running = self._is_running
+        if was_running:
+            self.halt()
+            
+        # QEMU reset might be 'R00' or 'monitor system_reset'
+        cmd = b"qRcmd," + b"system_reset".hex().encode("ascii")
+        try:
+            self._send_command(cmd)
+        except GDBError:
+            pass
+            
+        if was_running:
+            self.resume()
+        else:
+            self._is_running = False
+
+    def halt(self):
+        # Send Ctrl-C to interrupt
+        if not self._socket:
+            raise GDBError("Socket is not open")
+        self._socket.sendall(b"\x03")
+        # Try to query the current state instead of waiting blindly for an out-of-band stop reply
+        try:
+            self._send_command(b"?")
+        except socket.timeout:
+            raise GDBError("Timeout waiting for target to halt")
+        self._is_running = False
+
+    def reset_and_halt(self):
+        self.reset()
+        self.halt()
+
+    # Override resume specifically for the blocking nature
+    def resume(self):
+        if not self._socket:
+            raise GDBError("Socket is not open")
+        cmd = b"c"
+        packet = b"$" + cmd + b"#" + _checksum(cmd)
+        self._socket.sendall(packet)
+        # Wait for ack
+        while True:
+            ack = self._sock_file.read(1)
+            if ack == b'+':
+                break
+            elif ack == b'-':
+                self._socket.sendall(packet)
+            elif not ack:
+                raise GDBError("Connection closed by remote")
+        # Do NOT wait for '$' here because 'c' replies only when target stops.
+        self._is_running = True
+
+    def start_gdbserver(self, port, logging=True, blocking=True):
+        pass # QEMU is already the GDB server
+
+    @property
+    def probe_name(self) -> str:
+        return "QEMU Emulator"

--- a/gnwmanager/ocdbackend/gdb_backend.py
+++ b/gnwmanager/ocdbackend/gdb_backend.py
@@ -1,18 +1,21 @@
-import os
+import contextlib
 import socket
-from time import sleep
 
 from gnwmanager.exceptions import DebugProbeConnectionError
 from gnwmanager.ocdbackend.base import OCDBackend, TransferErrors
 
+
 class GDBError(DebugProbeConnectionError):
     pass
 
+
 TransferErrors.add(GDBError)
+
 
 def _checksum(data: bytes) -> bytes:
     c = sum(data) % 256
     return f"{c:02x}".encode("ascii")
+
 
 class GDBBackend(OCDBackend):
     def __init__(self, host: str = "localhost", port: int = 1234):
@@ -31,58 +34,58 @@ class GDBBackend(OCDBackend):
         # read). Without this, Nagle's algorithm on this socket combines with
         # the peer's delayed-ACK timer to add a fixed ~40ms stall to every
         # single request/response round trip -- measured directly against
-        # qemu-gnw's gdbstub (a `gnwmanager --qemu info` call went from ~6.7s,
+        # qemu-gnw's gdbstub (a `gnwmanager --backend gdb info` call went from ~6.7s,
         # matching real hardware over OpenOCD, to ~39s with this unset).
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         try:
             self._socket.connect((self.host, self.port))
             self._sock_file = self._socket.makefile("rb", buffering=8192)
         except (OSError, ConnectionRefusedError) as e:
-            raise DebugProbeConnectionError(f"Could not connect to QEMU GDB server at {self.host}:{self.port}. Is QEMU running with '-gdb tcp::{self.port}'?") from e
-        
+            raise DebugProbeConnectionError(
+                f"Could not connect to QEMU GDB server at {self.host}:{self.port}. "
+                f"Is QEMU running with '-gdb tcp::{self.port}'?"
+            ) from e
+
         # Initial handshake: Tell GDB stub what we support
-        try:
+        # Some very simple stubs might not support qSupported
+        with contextlib.suppress(GDBError):
             self._send_command(b"qSupported:multiprocess+;xmlRegisters=i386;qRelocInsn+")
-        except GDBError:
-            pass  # Some very simple stubs might not support qSupported
-            
+
         # QEMU's GDB stub halts the VM when a client connects.
         # We explicitly resume it to match physical probe behavior.
         self.resume()
-            
+
         return self
 
     def close(self):
         if self._socket:
-            if hasattr(self, '_sock_file') and self._sock_file:
+            if hasattr(self, "_sock_file") and self._sock_file:
                 self._sock_file.close()
-            try:
+            with contextlib.suppress(OSError):
                 self._socket.close()
-            except OSError:
-                pass
             self._socket = None
 
     def _send_command(self, cmd: bytes) -> bytes:
         if not self._socket:
             raise GDBError("Socket is not open")
-        
+
         packet = b"$" + cmd + b"#" + _checksum(cmd)
         self._socket.sendall(packet)
-        
+
         # Wait for ack '+'
         while True:
             c = self._sock_file.read(1)
             if not c:
                 raise GDBError("Connection closed by remote")
-            if c == b'+':
+            if c == b"+":
                 break
-            elif c == b'-':
+            elif c == b"-":
                 self._socket.sendall(packet)
-            elif c == b'$':
+            elif c == b"$":
                 # We got a packet instead of an ack. It's likely an asynchronous stop reply.
                 # We need to read it, ack it, and then keep waiting for our ack or response.
                 self._read_packet_data()
-                
+
         # Wait for the actual reply packet
         while True:
             reply = self._wait_for_packet()
@@ -90,14 +93,14 @@ class GDBBackend(OCDBackend):
             # then it's an asynchronous notification. We should probably return it if we asked for it,
             # or ignore it if it's out of band.
             # For simplicity, if cmd is '?', we return the stop reply.
-            if cmd == b'?' or not reply.startswith((b'T', b'S', b'W', b'X')):
+            if cmd == b"?" or not reply.startswith((b"T", b"S", b"W", b"X")):
                 break
             # Otherwise we ignore the out-of-band stop reply and wait for the real reply
-            
-        if reply.startswith(b'E'):
+
+        if reply.startswith(b"E"):
             err_code = reply[1:].decode("ascii")
             raise GDBError(f"GDB error response: {err_code} for command {cmd.decode('ascii', errors='ignore')}")
-            
+
         return reply
 
     def _read_packet_data(self) -> bytes:
@@ -107,13 +110,13 @@ class GDBBackend(OCDBackend):
             c = self._sock_file.read(1)
             if not c:
                 raise GDBError("Connection closed by remote")
-            if c == b'#':
+            if c == b"#":
                 break
             reply.extend(c)
         # read checksum
         self._sock_file.read(2)
         # Send ack
-        self._socket.sendall(b'+')
+        self._socket.sendall(b"+")
         return bytes(reply)
 
     def _wait_for_packet(self) -> bytes:
@@ -121,7 +124,7 @@ class GDBBackend(OCDBackend):
             c = self._sock_file.read(1)
             if not c:
                 raise GDBError("Connection closed by remote")
-            if c == b'$':
+            if c == b"$":
                 return self._read_packet_data()
             # Ignore anything else before '$'
 
@@ -136,7 +139,7 @@ class GDBBackend(OCDBackend):
         # memory read/write -- those are serviced via cpu_memory_rw_debug(),
         # which is exactly as safe to call from a running VM as a halted
         # one. GDBBackend is QEMU-only (see cli/main.py: only ever
-        # instantiated when --qemu is set; real hardware goes through
+        # instantiated when --backend gdb is used; real hardware goes through
         # OCDBackend/OpenOCDBackend instead), so this is always talking to
         # that patched gdbstub. Halting/resuming around every single read
         # was previously adding two full GDB round-trips (each bounded by
@@ -144,11 +147,11 @@ class GDBBackend(OCDBackend):
         # stm32h7b0-diag's harness.py) to every poll of a status flag --
         # confirmed root cause of multi-minute-to-hour diag-tool runs that
         # should take seconds under a heavily-loaded (near-100%-CPU) vCPU.
-        CHUNK_SIZE = 4096
+        chunk_size_max = 4096
         result = bytearray()
 
-        for offset in range(0, size, CHUNK_SIZE):
-            chunk_size = min(CHUNK_SIZE, size - offset)
+        for offset in range(0, size, chunk_size_max):
+            chunk_size = min(chunk_size_max, size - offset)
             cmd = f"m{(addr + offset):x},{chunk_size:x}".encode("ascii")
             reply = self._send_command(cmd)
             result.extend(bytes.fromhex(reply.decode("ascii")))
@@ -162,9 +165,9 @@ class GDBBackend(OCDBackend):
         # See read_memory()'s comment: 'M' is exempted from the halt gate
         # by the same qemu-gnw gdbstub patch, so no halt/resume needed here
         # either.
-        CHUNK_SIZE = 4096
-        for offset in range(0, len(data), CHUNK_SIZE):
-            chunk = data[offset:offset+CHUNK_SIZE]
+        chunk_size_max = 4096
+        for offset in range(0, len(data), chunk_size_max):
+            chunk = data[offset : offset + chunk_size_max]
             hex_data = chunk.hex()
             cmd = f"M{(addr + offset):x},{len(chunk):x}:{hex_data}".encode("ascii")
             reply = self._send_command(cmd)
@@ -194,14 +197,14 @@ class GDBBackend(OCDBackend):
         was_running = self._is_running
         if was_running:
             self.halt()
-            
+
         idx = self._get_reg_idx(name)
         cmd = f"p{idx:x}".encode("ascii")
         reply = self._send_command(cmd)
-        
+
         if was_running:
             self.resume()
-            
+
         # GDB returns little-endian hex string for registers usually
         data = bytes.fromhex(reply.decode("ascii"))
         return int.from_bytes(data, byteorder="little")
@@ -210,16 +213,16 @@ class GDBBackend(OCDBackend):
         was_running = self._is_running
         if was_running:
             self.halt()
-            
+
         idx = self._get_reg_idx(name)
         # 32-bit registers, little-endian hex string
         hex_val = val.to_bytes(4, byteorder="little").hex()
         cmd = f"P{idx:x}={hex_val}".encode("ascii")
         reply = self._send_command(cmd)
-        
+
         if was_running:
             self.resume()
-            
+
         if reply != b"OK":
             raise GDBError(f"Failed to write register, expected OK got {reply}")
 
@@ -231,14 +234,12 @@ class GDBBackend(OCDBackend):
         was_running = self._is_running
         if was_running:
             self.halt()
-            
+
         # QEMU reset might be 'R00' or 'monitor system_reset'
         cmd = b"qRcmd," + b"system_reset".hex().encode("ascii")
-        try:
+        with contextlib.suppress(GDBError):
             self._send_command(cmd)
-        except GDBError:
-            pass
-            
+
         if was_running:
             self.resume()
         else:
@@ -252,8 +253,8 @@ class GDBBackend(OCDBackend):
         # Try to query the current state instead of waiting blindly for an out-of-band stop reply
         try:
             self._send_command(b"?")
-        except socket.timeout:
-            raise GDBError("Timeout waiting for target to halt")
+        except socket.timeout as e:
+            raise GDBError("Timeout waiting for target to halt") from e
         self._is_running = False
 
     def reset_and_halt(self):
@@ -270,9 +271,9 @@ class GDBBackend(OCDBackend):
         # Wait for ack
         while True:
             ack = self._sock_file.read(1)
-            if ack == b'+':
+            if ack == b"+":
                 break
-            elif ack == b'-':
+            elif ack == b"-":
                 self._socket.sendall(packet)
             elif not ack:
                 raise GDBError("Connection closed by remote")
@@ -280,7 +281,7 @@ class GDBBackend(OCDBackend):
         self._is_running = True
 
     def start_gdbserver(self, port, logging=True, blocking=True):
-        pass # QEMU is already the GDB server
+        pass  # QEMU is already the GDB server
 
     @property
     def probe_name(self) -> str:

--- a/gnwmanager/ocdbackend/gdb_backend.py
+++ b/gnwmanager/ocdbackend/gdb_backend.py
@@ -64,23 +64,50 @@ class GDBBackend(OCDBackend):
             with contextlib.suppress(OSError):
                 self._socket.close()
             self._socket = None
+        self._is_running = False
+
+    def _read(self, n: int) -> bytes:
+        """Read exactly ``n`` bytes, translating socket failures into GDBError.
+
+        The socket carries a 5s timeout (see open()); without this translation a
+        raw socket.timeout would escape past TransferErrors' retry machinery and
+        main.py's DebugProbeConnectionError handling.
+        """
+        try:
+            data = self._sock_file.read(n)
+        except socket.timeout as e:
+            raise GDBError(f"Timed out waiting for {n} byte(s) from the GDB stub") from e
+        except OSError as e:
+            raise GDBError(f"Socket error while reading from the GDB stub: {e}") from e
+        if not data:
+            raise GDBError("Connection closed by remote")
+        return data
+
+    def _write(self, data: bytes):
+        """Send all of ``data``, translating socket failures into GDBError."""
+        if not self._socket:
+            raise GDBError("Socket is not open")
+        try:
+            self._socket.sendall(data)
+        except socket.timeout as e:
+            raise GDBError("Timed out sending to the GDB stub") from e
+        except OSError as e:
+            raise GDBError(f"Socket error while writing to the GDB stub: {e}") from e
 
     def _send_command(self, cmd: bytes) -> bytes:
         if not self._socket:
             raise GDBError("Socket is not open")
 
         packet = b"$" + cmd + b"#" + _checksum(cmd)
-        self._socket.sendall(packet)
+        self._write(packet)
 
         # Wait for ack '+'
         while True:
-            c = self._sock_file.read(1)
-            if not c:
-                raise GDBError("Connection closed by remote")
+            c = self._read(1)
             if c == b"+":
                 break
             elif c == b"-":
-                self._socket.sendall(packet)
+                self._write(packet)
             elif c == b"$":
                 # We got a packet instead of an ack. It's likely an asynchronous stop reply.
                 # We need to read it, ack it, and then keep waiting for our ack or response.
@@ -107,23 +134,32 @@ class GDBBackend(OCDBackend):
         # Assuming '$' was just read
         reply = bytearray()
         while True:
-            c = self._sock_file.read(1)
-            if not c:
-                raise GDBError("Connection closed by remote")
+            c = self._read(1)
             if c == b"#":
                 break
+            if c == b"*":
+                # Run-length encoding: the previous byte repeats an additional
+                # (count_char - 29) times. QEMU's gdbstub does not currently
+                # emit this on replies (gdb_put_packet_binary() copies the
+                # payload verbatim; its RLE handling is receive-side only), but
+                # the remote protocol permits any stub to, so decode it.
+                if not reply:
+                    raise GDBError("Malformed packet: RLE marker with no preceding byte")
+                repeat = self._read(1)[0] - 29
+                if repeat < 0:
+                    raise GDBError("Malformed packet: invalid RLE repeat count")
+                reply.extend(reply[-1:] * repeat)
+                continue
             reply.extend(c)
         # read checksum
-        self._sock_file.read(2)
+        self._read(2)
         # Send ack
-        self._socket.sendall(b"+")
+        self._write(b"+")
         return bytes(reply)
 
     def _wait_for_packet(self) -> bytes:
         while True:
-            c = self._sock_file.read(1)
-            if not c:
-                raise GDBError("Connection closed by remote")
+            c = self._read(1)
             if c == b"$":
                 return self._read_packet_data()
             # Ignore anything else before '$'
@@ -132,21 +168,13 @@ class GDBBackend(OCDBackend):
         if size == 0:
             return b""
 
-        # Deliberately does NOT halt/resume around this like the other
-        # accessors below: qemu-gnw's gdbstub (gdbstub/gdbstub.c, see
-        # "Commit gdbstub memory-read/write non-halting fix") only gates
-        # the halt-while-running check for commands other than plain 'm'/'M'
-        # memory read/write -- those are serviced via cpu_memory_rw_debug(),
-        # which is exactly as safe to call from a running VM as a halted
-        # one. GDBBackend is QEMU-only (see cli/main.py: only ever
-        # instantiated when --backend gdb is used; real hardware goes through
-        # OCDBackend/OpenOCDBackend instead), so this is always talking to
-        # that patched gdbstub. Halting/resuming around every single read
-        # was previously adding two full GDB round-trips (each bounded by
-        # this socket's 5s timeout, retried up to 5x by callers like
-        # stm32h7b0-diag's harness.py) to every poll of a status flag --
-        # confirmed root cause of multi-minute-to-hour diag-tool runs that
-        # should take seconds under a heavily-loaded (near-100%-CPU) vCPU.
+        # Deliberately does NOT halt/resume around this like the other accessors
+        # below. Plain 'm'/'M' memory access is serviced by QEMU's gdbstub via
+        # cpu_memory_rw_debug(), which is exactly as safe to call against a
+        # running VM as a halted one. Halting/resuming around every single read
+        # added two full GDB round-trips (each bounded by this socket's 5s
+        # timeout) to every poll of a status flag, which under a heavily-loaded
+        # vCPU turned runs that should take seconds into minutes.
         chunk_size_max = 4096
         result = bytearray()
 
@@ -154,17 +182,29 @@ class GDBBackend(OCDBackend):
             chunk_size = min(chunk_size_max, size - offset)
             cmd = f"m{(addr + offset):x},{chunk_size:x}".encode("ascii")
             reply = self._send_command(cmd)
-            result.extend(bytes.fromhex(reply.decode("ascii")))
+            chunk = self._decode_hex(reply, cmd)
+            # A stub is permitted to return fewer bytes than requested; without
+            # this check that would silently yield truncated data to callers.
+            if len(chunk) != chunk_size:
+                raise GDBError(f"Short read at 0x{addr + offset:08x}: requested {chunk_size} bytes, got {len(chunk)}")
+            result.extend(chunk)
 
         return bytes(result)
+
+    @staticmethod
+    def _decode_hex(reply: bytes, cmd: bytes) -> bytes:
+        """Decode a hex-string reply, raising GDBError rather than ValueError."""
+        try:
+            return bytes.fromhex(reply.decode("ascii"))
+        except (ValueError, UnicodeDecodeError) as e:
+            raise GDBError(f"Malformed hex reply {reply!r} for command {cmd.decode('ascii', errors='ignore')}") from e
 
     def write_memory(self, addr: int, data: bytes):
         if not data:
             return
 
-        # See read_memory()'s comment: 'M' is exempted from the halt gate
-        # by the same qemu-gnw gdbstub patch, so no halt/resume needed here
-        # either.
+        # See read_memory()'s comment: 'M' goes through the same
+        # cpu_memory_rw_debug() path, so no halt/resume is needed here either.
         chunk_size_max = 4096
         for offset in range(0, len(data), chunk_size_max):
             chunk = data[offset : offset + chunk_size_max]
@@ -206,7 +246,7 @@ class GDBBackend(OCDBackend):
             self.resume()
 
         # GDB returns little-endian hex string for registers usually
-        data = bytes.fromhex(reply.decode("ascii"))
+        data = self._decode_hex(reply, cmd)
         return int.from_bytes(data, byteorder="little")
 
     def write_register(self, name: str, val: int):
@@ -231,30 +271,23 @@ class GDBBackend(OCDBackend):
         pass
 
     def reset(self):
-        was_running = self._is_running
-        if was_running:
+        if self._is_running:
             self.halt()
 
-        # QEMU reset might be 'R00' or 'monitor system_reset'
+        # 'monitor system_reset'. Failures propagate: silently suppressing them
+        # would report a successful reset having reset nothing.
         cmd = b"qRcmd," + b"system_reset".hex().encode("ascii")
-        with contextlib.suppress(GDBError):
-            self._send_command(cmd)
+        self._send_command(cmd)
 
-        if was_running:
-            self.resume()
-        else:
-            self._is_running = False
+        # Matches OpenOCDBackend/PyOCDBackend, whose reset() unconditionally
+        # leaves the target running regardless of its prior state.
+        self.resume()
 
     def halt(self):
         # Send Ctrl-C to interrupt
-        if not self._socket:
-            raise GDBError("Socket is not open")
-        self._socket.sendall(b"\x03")
+        self._write(b"\x03")
         # Try to query the current state instead of waiting blindly for an out-of-band stop reply
-        try:
-            self._send_command(b"?")
-        except socket.timeout as e:
-            raise GDBError("Timeout waiting for target to halt") from e
+        self._send_command(b"?")
         self._is_running = False
 
     def reset_and_halt(self):
@@ -267,21 +300,27 @@ class GDBBackend(OCDBackend):
             raise GDBError("Socket is not open")
         cmd = b"c"
         packet = b"$" + cmd + b"#" + _checksum(cmd)
-        self._socket.sendall(packet)
+        self._write(packet)
         # Wait for ack
         while True:
-            ack = self._sock_file.read(1)
+            ack = self._read(1)
             if ack == b"+":
                 break
             elif ack == b"-":
-                self._socket.sendall(packet)
-            elif not ack:
-                raise GDBError("Connection closed by remote")
+                self._write(packet)
         # Do NOT wait for '$' here because 'c' replies only when target stops.
         self._is_running = True
 
     def start_gdbserver(self, port, logging=True, blocking=True):
-        pass  # QEMU is already the GDB server
+        # QEMU is itself the GDB server, and its stub accepts only a single
+        # client -- which this backend is already occupying. Returning silently
+        # would leave `gnwmanager gdbserver` exiting instantly and `gnwmanager
+        # gdb` launching gdb against a port nothing is listening on.
+        raise NotImplementedError(
+            f"QEMU is already the GDB server on port {self.port}. Connect gdb to it directly with "
+            f"'target extended-remote {self.host}:{self.port}' (without a concurrent gnwmanager session, "
+            f"since QEMU's gdbstub accepts only one client)."
+        )
 
     @property
     def probe_name(self) -> str:

--- a/tests/test_gdb_backend.py
+++ b/tests/test_gdb_backend.py
@@ -1,0 +1,129 @@
+import socket
+
+import pytest
+
+from gnwmanager.ocdbackend.gdb_backend import GDBBackend, GDBError, _checksum
+
+
+class FakeSockFile:
+    """Stands in for the socket's buffered file object."""
+
+    def __init__(self, data: bytes, raise_timeout: bool = False):
+        self.data = data
+        self.pos = 0
+        self.raise_timeout = raise_timeout
+
+    def read(self, n: int) -> bytes:
+        if self.raise_timeout:
+            raise socket.timeout
+        chunk = self.data[self.pos : self.pos + n]
+        self.pos += len(chunk)
+        return chunk
+
+    def close(self):
+        pass
+
+
+class FakeSocket:
+    def __init__(self):
+        self.sent = bytearray()
+
+    def sendall(self, data: bytes):
+        self.sent.extend(data)
+
+    def close(self):
+        pass
+
+
+def make_backend(reply_stream: bytes, raise_timeout: bool = False) -> GDBBackend:
+    backend = GDBBackend()
+    backend._socket = FakeSocket()
+    backend._sock_file = FakeSockFile(reply_stream, raise_timeout=raise_timeout)
+    return backend
+
+
+def packet(payload: bytes) -> bytes:
+    """Wrap a raw (already-encoded) payload as an acked reply packet."""
+    return b"+$" + payload + b"#" + _checksum(payload)
+
+
+def test_rle_is_expanded():
+    # RLE repeats the preceding *character* of the packet stream, i.e. a hex
+    # nibble. "ff*!" -> 'f' plus 4 more (ord('!') - 29) -> "ffffff" -> 3 bytes.
+    backend = make_backend(packet(b"ff*!"))
+    assert backend.read_memory(0x2000_0000, 3) == b"\xff\xff\xff"
+
+
+def test_rle_without_preceding_byte_is_an_error():
+    backend = make_backend(packet(b"* "))
+    with pytest.raises(GDBError, match="RLE marker with no preceding byte"):
+        backend.read_memory(0x2000_0000, 1)
+
+
+def test_rle_invalid_repeat_count_is_an_error():
+    backend = make_backend(packet(b"ff*\x01"))
+    with pytest.raises(GDBError, match="invalid RLE repeat count"):
+        backend.read_memory(0x2000_0000, 1)
+
+
+def test_short_read_is_detected():
+    # Asked for 4 bytes, stub returns 2.
+    backend = make_backend(packet(b"deadbeef"[:4]))
+    with pytest.raises(GDBError, match="Short read"):
+        backend.read_memory(0x2000_0000, 4)
+
+
+def test_read_memory_happy_path():
+    backend = make_backend(packet(b"deadbeef"))
+    assert backend.read_memory(0x2000_0000, 4) == b"\xde\xad\xbe\xef"
+
+
+def test_malformed_hex_raises_gdb_error_not_value_error():
+    backend = make_backend(packet(b"zzzz"))
+    with pytest.raises(GDBError, match="Malformed hex reply"):
+        backend.read_memory(0x2000_0000, 2)
+
+
+def test_timeout_is_translated_to_gdb_error():
+    backend = make_backend(b"", raise_timeout=True)
+    with pytest.raises(GDBError, match="Timed out"):
+        backend.read_memory(0x2000_0000, 4)
+
+
+def test_closed_connection_is_translated_to_gdb_error():
+    backend = make_backend(b"")
+    with pytest.raises(GDBError, match="Connection closed by remote"):
+        backend.read_memory(0x2000_0000, 4)
+
+
+def test_error_reply_raises_gdb_error():
+    backend = make_backend(packet(b"E01"))
+    with pytest.raises(GDBError, match="GDB error response"):
+        backend.read_memory(0x2000_0000, 4)
+
+
+def test_reset_leaves_target_running():
+    # Reply to the halt '?' query, then to qRcmd. resume() only needs an ack.
+    backend = make_backend(packet(b"T05") + packet(b"OK") + b"+")
+    backend._is_running = True
+    backend.reset()
+    assert backend._is_running is True
+
+
+def test_reset_propagates_failure():
+    backend = make_backend(packet(b"E01"))
+    with pytest.raises(GDBError):
+        backend.reset()
+
+
+def test_start_gdbserver_raises_with_actionable_message():
+    backend = GDBBackend(port=1234)
+    with pytest.raises(NotImplementedError, match="already the GDB server on port 1234"):
+        backend.start_gdbserver(3333)
+
+
+def test_close_resets_running_state():
+    backend = make_backend(b"")
+    backend._is_running = True
+    backend.close()
+    assert backend._is_running is False


### PR DESCRIPTION
Adds a GDBBackend (OCDBackend registry member "gdb") that connects to a QEMU instance's gdbstub over TCP, so gnwmanager can target emulated devices the same way it targets physical ones via openocd/pyocd. Selected via the existing --backend/-b flag, with --gdb-host/--gdb-port to configure the target (defaults to localhost:1234).